### PR TITLE
Enhance payments history with contact info and modal

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -215,11 +215,13 @@ class Takamoa_Papi_Integration_Admin
         ?>
         <div class="wrap">
             <h1>Historique des paiements</h1>
-            <table class="widefat striped">
+            <table id="takamoa-payments-table" class="widefat striped">
                 <thead>
                     <tr>
                         <th>Référence</th>
                         <th>Nom client</th>
+                        <th>Email</th>
+                        <th>Téléphone</th>
                         <th>Montant</th>
                         <th>Status</th>
                         <th>Méthode</th>
@@ -228,9 +230,20 @@ class Takamoa_Papi_Integration_Admin
                 </thead>
                 <tbody>
                 <?php foreach ($results as $row): ?>
-                    <tr>
+                    <tr class="payment-row"
+                        data-reference="<?= esc_attr($row->reference) ?>"
+                        data-client="<?= esc_attr($row->client_name) ?>"
+                        data-email="<?= esc_attr($row->payer_email) ?>"
+                        data-phone="<?= esc_attr($row->payer_phone) ?>"
+                        data-amount="<?= esc_attr(number_format($row->amount, 0, '', ' ') . ' MGA') ?>"
+                        data-status="<?= esc_attr($row->payment_status) ?>"
+                        data-method="<?= esc_attr($row->payment_method ?: '—') ?>"
+                        data-date="<?= esc_attr($row->created_at) ?>"
+                        data-description="<?= esc_attr($row->description) ?>">
                         <td><?= esc_html($row->reference) ?></td>
                         <td><?= esc_html($row->client_name) ?></td>
+                        <td><?= esc_html($row->payer_email ?: '—') ?></td>
+                        <td><?= esc_html($row->payer_phone ?: '—') ?></td>
                         <td><?= number_format($row->amount, 0, '', ' ') ?> MGA</td>
                         <td><?= esc_html($row->payment_status) ?></td>
                         <td><?= esc_html($row->payment_method ?: '—') ?></td>
@@ -239,6 +252,32 @@ class Takamoa_Papi_Integration_Admin
                 <?php endforeach; ?>
                 </tbody>
             </table>
+
+            <div class="modal fade" id="paymentModal" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Détails du paiement</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <table class="table table-borderless">
+                                <tbody>
+                                    <tr><th>Référence</th><td id="modal-reference"></td></tr>
+                                    <tr><th>Nom client</th><td id="modal-name"></td></tr>
+                                    <tr><th>Email</th><td id="modal-email"></td></tr>
+                                    <tr><th>Téléphone</th><td id="modal-phone"></td></tr>
+                                    <tr><th>Montant</th><td id="modal-amount"></td></tr>
+                                    <tr><th>Status</th><td id="modal-status"></td></tr>
+                                    <tr><th>Méthode</th><td id="modal-method"></td></tr>
+                                    <tr><th>Date</th><td id="modal-date"></td></tr>
+                                    <tr><th>Description</th><td id="modal-description"></td></tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
         <?php
     }

--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -254,14 +254,14 @@ class Takamoa_Papi_Integration_Admin
             </table>
 
             <div class="modal fade" id="paymentModal" tabindex="-1" aria-hidden="true">
-                <div class="modal-dialog">
+                <div class="modal-dialog modal-dialog-centered modal-lg">
                     <div class="modal-content">
                         <div class="modal-header">
                             <h5 class="modal-title">Détails du paiement</h5>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">
-                            <table class="table table-borderless">
+                            <table class="table table-striped">
                                 <tbody>
                                     <tr><th>Référence</th><td id="modal-reference"></td></tr>
                                     <tr><th>Nom client</th><td id="modal-name"></td></tr>
@@ -274,6 +274,9 @@ class Takamoa_Papi_Integration_Admin
                                     <tr><th>Description</th><td id="modal-description"></td></tr>
                                 </tbody>
                             </table>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
                         </div>
                     </div>
                 </div>

--- a/admin/css/takamoa-papi-integration-admin.css
+++ b/admin/css/takamoa-papi-integration-admin.css
@@ -21,3 +21,29 @@
 .payment-row {
     cursor: pointer;
 }
+
+/* DataTables custom styling */
+.datatable-header .dataTables_length,
+.datatable-header .dataTables_filter,
+.datatable-footer .dataTables_info,
+.datatable-footer .dataTables_paginate {
+    margin-bottom: 0;
+}
+
+.dataTables_wrapper .dataTables_filter input {
+    width: auto;
+}
+
+.dataTables_wrapper .dataTables_paginate .btn {
+    border-radius: 0.25rem;
+}
+
+.dataTables_wrapper .dataTables_paginate .btn-primary {
+    background-color: #0073aa;
+    border-color: #0073aa;
+}
+
+.dataTables_wrapper .dataTables_paginate .btn-primary:hover {
+    background-color: #006799;
+    border-color: #006799;
+}

--- a/admin/css/takamoa-papi-integration-admin.css
+++ b/admin/css/takamoa-papi-integration-admin.css
@@ -39,18 +39,28 @@
     flex-wrap: wrap;
 }
 
-.dataTables_wrapper .dt-paging .btn {
+.dataTables_wrapper .dt-paging .dt-paging-button {
+    margin-right: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid #dee2e6;
+    background-color: #f8f9fa;
+    color: #212529;
     border-radius: 0.25rem;
 }
 
-.dataTables_wrapper .dt-paging .btn-primary {
+.dataTables_wrapper .dt-paging .dt-paging-button.current {
     background-color: #0073aa;
     border-color: #0073aa;
+    color: #fff;
 }
 
-.dataTables_wrapper .dt-paging .btn-primary:hover {
-    background-color: #006799;
-    border-color: #006799;
+.dataTables_wrapper .dt-paging .dt-paging-button:not(.disabled):hover {
+    background-color: #e9ecef;
+}
+
+.dataTables_wrapper .dt-paging .dt-paging-button.disabled {
+    opacity: 0.65;
+    cursor: default;
 }
 
 /* Payment modal styling */

--- a/admin/css/takamoa-papi-integration-admin.css
+++ b/admin/css/takamoa-papi-integration-admin.css
@@ -30,16 +30,16 @@
     margin-bottom: 0;
 }
 
-.dataTables_wrapper .dataTables_filter input {
+.dataTables_filter input {
     width: auto;
 }
 
-.dataTables_wrapper .dt-paging {
+.dt-paging {
     display: flex;
     flex-wrap: wrap;
 }
 
-.dataTables_wrapper .dt-paging .dt-paging-button {
+.dt-paging .dt-paging-button {
     margin-right: 0.25rem;
     padding: 0.25rem 0.5rem;
     border: 1px solid #dee2e6;
@@ -48,17 +48,16 @@
     border-radius: 0.25rem;
 }
 
-.dataTables_wrapper .dt-paging .dt-paging-button.current {
+.dt-paging .dt-paging-button.current {
     background-color: #0073aa;
     border-color: #0073aa;
     color: #fff;
 }
-
-.dataTables_wrapper .dt-paging .dt-paging-button:not(.disabled):hover {
+.dt-paging .dt-paging-button:not(.disabled):hover {
     background-color: #e9ecef;
 }
 
-.dataTables_wrapper .dt-paging .dt-paging-button.disabled {
+.dt-paging .dt-paging-button.disabled {
     opacity: 0.65;
     cursor: default;
 }

--- a/admin/css/takamoa-papi-integration-admin.css
+++ b/admin/css/takamoa-papi-integration-admin.css
@@ -26,7 +26,7 @@
 .datatable-header .dataTables_length,
 .datatable-header .dataTables_filter,
 .datatable-footer .dataTables_info,
-.datatable-footer .dataTables_paginate {
+.datatable-footer .dt-paging {
     margin-bottom: 0;
 }
 
@@ -34,16 +34,36 @@
     width: auto;
 }
 
-.dataTables_wrapper .dataTables_paginate .btn {
+.dataTables_wrapper .dt-paging {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.dataTables_wrapper .dt-paging .btn {
     border-radius: 0.25rem;
 }
 
-.dataTables_wrapper .dataTables_paginate .btn-primary {
+.dataTables_wrapper .dt-paging .btn-primary {
     background-color: #0073aa;
     border-color: #0073aa;
 }
 
-.dataTables_wrapper .dataTables_paginate .btn-primary:hover {
+.dataTables_wrapper .dt-paging .btn-primary:hover {
     background-color: #006799;
     border-color: #006799;
+}
+
+/* Payment modal styling */
+#paymentModal .modal-header {
+    background-color: #0073aa;
+    color: #fff;
+}
+
+#paymentModal .modal-header .btn-close {
+    filter: invert(1);
+}
+
+#paymentModal .table th {
+    width: 40%;
+    white-space: nowrap;
 }

--- a/admin/css/takamoa-papi-integration-admin.css
+++ b/admin/css/takamoa-papi-integration-admin.css
@@ -16,3 +16,8 @@
         width: 100%;
     }
 }
+
+/* Payments table */
+.payment-row {
+    cursor: pointer;
+}

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -1,5 +1,24 @@
 jQuery(document).ready(function($) {
-    var table = $('#takamoa-payments-table').DataTable();
+    var table = $('#takamoa-payments-table').DataTable({
+        pageLength: 10,
+        lengthMenu: [5, 10, 25, 50],
+        dom: '<"datatable-header d-flex justify-content-between align-items-center mb-3"lf>rt<"datatable-footer d-flex justify-content-between align-items-center mt-3"ip>',
+        language: {
+            lengthMenu: '_MENU_',
+            search: '',
+            searchPlaceholder: 'Search…'
+        },
+        drawCallback: function() {
+            var paginate = $('#takamoa-payments-table_wrapper .dataTables_paginate');
+            paginate.find('a').addClass('btn btn-sm btn-light me-1');
+            paginate.find('a.current').removeClass('btn-light').addClass('btn-primary text-white');
+        }
+    });
+
+    var wrapper = $('#takamoa-payments-table_wrapper');
+    wrapper.find('.dataTables_length select').addClass('form-select form-select-sm');
+    wrapper.find('.dataTables_filter input').addClass('form-control form-control-sm').attr('placeholder', 'Search…');
+    wrapper.find('.dataTables_length label, .dataTables_filter label').addClass('d-flex align-items-center gap-2 mb-0');
 
     $('#takamoa-payments-table tbody').on('click', 'tr.payment-row', function() {
         var row = $(this);

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -1,3 +1,19 @@
 jQuery(document).ready(function($) {
-    
+    var table = $('#takamoa-payments-table').DataTable();
+
+    $('#takamoa-payments-table tbody').on('click', 'tr.payment-row', function() {
+        var row = $(this);
+        $('#modal-reference').text(row.data('reference'));
+        $('#modal-name').text(row.data('client'));
+        $('#modal-email').text(row.data('email') || '—');
+        $('#modal-phone').text(row.data('phone') || '—');
+        $('#modal-amount').text(row.data('amount'));
+        $('#modal-status').text(row.data('status'));
+        $('#modal-method').text(row.data('method'));
+        $('#modal-date').text(row.data('date'));
+        $('#modal-description').text(row.data('description') || '—');
+
+        var modal = new bootstrap.Modal(document.getElementById('paymentModal'));
+        modal.show();
+    });
 });

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -8,11 +8,6 @@ jQuery(document).ready(function($) {
             lengthMenu: '_MENU_',
             search: '',
             searchPlaceholder: 'Search…'
-        },
-        drawCallback: function() {
-            var paginate = $('#takamoa-payments-table_wrapper .dt-paging');
-            paginate.find('button').addClass('btn btn-sm btn-light me-1');
-            paginate.find('button.current').removeClass('btn-light').addClass('btn-primary text-white');
         }
     });
 

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -2,6 +2,7 @@ jQuery(document).ready(function($) {
     var table = $('#takamoa-payments-table').DataTable({
         pageLength: 10,
         lengthMenu: [5, 10, 25, 50],
+        pagingType: 'full_numbers',
         dom: '<"datatable-header d-flex justify-content-between align-items-center mb-3"lf>rt<"datatable-footer d-flex justify-content-between align-items-center mt-3"ip>',
         language: {
             lengthMenu: '_MENU_',
@@ -9,9 +10,9 @@ jQuery(document).ready(function($) {
             searchPlaceholder: 'Search…'
         },
         drawCallback: function() {
-            var paginate = $('#takamoa-payments-table_wrapper .dataTables_paginate');
-            paginate.find('a').addClass('btn btn-sm btn-light me-1');
-            paginate.find('a.current').removeClass('btn-light').addClass('btn-primary text-white');
+            var paginate = $('#takamoa-payments-table_wrapper .dt-paging');
+            paginate.find('button').addClass('btn btn-sm btn-light me-1');
+            paginate.find('button.current').removeClass('btn-light').addClass('btn-primary text-white');
         }
     });
 


### PR DESCRIPTION
## Summary
- show payer email and phone on payments history table
- open a Bootstrap modal with detailed payment info when clicking a row
- initialize DataTables and style rows as clickable

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_6895d5a0199c832e93c6e828ec1561a2