### PR TITLE
feat: add email notifications and admin resend

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -41,11 +41,14 @@ class Takamoa_Papi_Integration_Admin
 		if (strpos(get_current_screen()->id, $this->plugin_name) !== false) {
 			wp_enqueue_script('datatables-script', 'https://cdn.datatables.net/2.0.8/js/dataTables.min.js', array('jquery'), null, true);
 			wp_enqueue_script('bootstrap-js', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js', array('jquery'), null, true);
-			wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/takamoa-papi-integration-admin.js', array('jquery', 'datatables-script'), $this->version, true);
-			wp_localize_script($this->plugin_name, 'takamoaAjax', array('ajaxurl' => admin_url('admin-ajax.php')));
-			wp_enqueue_media();
-		}
-	}
+                        wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/takamoa-papi-integration-admin.js', array('jquery', 'datatables-script'), $this->version, true);
+                        wp_localize_script($this->plugin_name, 'takamoaAjax', array(
+                                'ajaxurl' => admin_url('admin-ajax.php'),
+                                'nonce'   => wp_create_nonce('takamoa_papi_nonce'),
+                        ));
+                        wp_enqueue_media();
+                }
+        }
 
 	/**
 	 * Add admin menu.
@@ -226,6 +229,7 @@ class Takamoa_Papi_Integration_Admin
                         <th>Status</th>
                         <th>Méthode</th>
                         <th>Date</th>
+                        <th>Action</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -265,6 +269,7 @@ class Takamoa_Papi_Integration_Admin
                         <td><?= esc_html($row->payment_status) ?></td>
                         <td><?= esc_html($row->payment_method ?: '—') ?></td>
                         <td><?= esc_html($row->created_at) ?></td>
+                        <td><button type="button" class="button takamoa-notify">Notifier</button></td>
                     </tr>
                 <?php endforeach; ?>
                 </tbody>

--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -41,47 +41,47 @@ class Takamoa_Papi_Integration_Admin
 		if (strpos(get_current_screen()->id, $this->plugin_name) !== false) {
 			wp_enqueue_script('datatables-script', 'https://cdn.datatables.net/2.0.8/js/dataTables.min.js', array('jquery'), null, true);
 			wp_enqueue_script('bootstrap-js', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js', array('jquery'), null, true);
-                        wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/takamoa-papi-integration-admin.js', array('jquery', 'datatables-script'), $this->version, true);
-                        wp_localize_script($this->plugin_name, 'takamoaAjax', array(
-                                'ajaxurl' => admin_url('admin-ajax.php'),
-                                'nonce'   => wp_create_nonce('takamoa_papi_nonce'),
-                        ));
-                        wp_enqueue_media();
-                }
-        }
+						wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/takamoa-papi-integration-admin.js', array('jquery', 'datatables-script'), $this->version, true);
+						wp_localize_script($this->plugin_name, 'takamoaAjax', array(
+								'ajaxurl' => admin_url('admin-ajax.php'),
+								'nonce'   => wp_create_nonce('takamoa_papi_nonce'),
+						));
+						wp_enqueue_media();
+				}
+		}
 
 	/**
 	 * Add admin menu.
 	 */
 	public function add_menu()
 	{
-        add_menu_page(
-            'Takamoa x Papi Intégration',
-            'Takamoa Papi',
-            'manage_options',
-            $this->plugin_name,
-            array($this, 'display_admin_page'),
-            'dashicons-admin-generic',
-            6
-        );
-    
-        add_submenu_page(
-            $this->plugin_name,
-            'Historique des paiements',
-            'Paiements',
-            'manage_options',
-            $this->plugin_name . '-payments',
-            array($this, 'display_payments_page')
-        );
-    
-        add_submenu_page(
-            $this->plugin_name,
-            'Options avancées',
-            'Options',
-            'manage_options',
-            $this->plugin_name . '-settings',
-            array($this, 'display_options_page')
-        );
+		add_menu_page(
+			'Takamoa x Papi Intégration',
+			'Takamoa Papi',
+			'manage_options',
+			$this->plugin_name,
+			array($this, 'display_admin_page'),
+			'dashicons-admin-generic',
+			6
+		);
+	
+		add_submenu_page(
+			$this->plugin_name,
+			'Historique des paiements',
+			'Paiements',
+			'manage_options',
+			$this->plugin_name . '-payments',
+			array($this, 'display_payments_page')
+		);
+	
+		add_submenu_page(
+			$this->plugin_name,
+			'Options avancées',
+			'Options',
+			'manage_options',
+			$this->plugin_name . '-settings',
+			array($this, 'display_options_page')
+		);
 	}
 
 	/**
@@ -90,23 +90,23 @@ class Takamoa_Papi_Integration_Admin
 	public function register_settings()
 	{
 		register_setting('takamoa_papi_key_group', 'takamoa_papi_api_key');
-                
-        // URLs
-        register_setting('takamoa_papi_settings_group', 'takamoa_papi_success_url');
-        register_setting('takamoa_papi_settings_group', 'takamoa_papi_failure_url');
+				
+		// URLs
+		register_setting('takamoa_papi_settings_group', 'takamoa_papi_success_url');
+		register_setting('takamoa_papi_settings_group', 'takamoa_papi_failure_url');
 
-        // Valid duration
-        register_setting('takamoa_papi_settings_group', 'takamoa_papi_valid_duration');
+		// Valid duration
+		register_setting('takamoa_papi_settings_group', 'takamoa_papi_valid_duration');
 
-        // Providers
-        register_setting('takamoa_papi_settings_group', 'takamoa_papi_providers');
+		// Providers
+		register_setting('takamoa_papi_settings_group', 'takamoa_papi_providers');
 
-        // Champs visibles dans le formulaire
-        register_setting('takamoa_papi_settings_group', 'takamoa_papi_optional_fields');
+		// Champs visibles dans le formulaire
+		register_setting('takamoa_papi_settings_group', 'takamoa_papi_optional_fields');
 
-        // Mode test
-        register_setting('takamoa_papi_settings_group', 'takamoa_papi_test_mode');
-        register_setting('takamoa_papi_settings_group', 'takamoa_papi_test_reason');
+		// Mode test
+		register_setting('takamoa_papi_settings_group', 'takamoa_papi_test_mode');
+		register_setting('takamoa_papi_settings_group', 'takamoa_papi_test_reason');
 
 		add_settings_section(
 			'takamoa_papi_main_section',
@@ -128,63 +128,63 @@ class Takamoa_Papi_Integration_Admin
 			'takamoa_papi_main_section'
 		);
 
-        add_settings_section(
-            'takamoa_papi_extra_section',
-            'Options supplémentaires',
-            null,
-            $this->plugin_name . '-settings'
-        );
-        
-        // Champs de redirection
-        add_settings_field('takamoa_papi_success_url', 'URL après succès', function () {
-            $default = home_url('/paiementreussi');
-            $value = esc_attr(get_option('takamoa_papi_success_url', $default));
-            echo "<input type='url' name='takamoa_papi_success_url' value='$value' style='width: 400px;'>";
-            echo "<p class='description'>Par défaut : <code>$default</code></p>";
-        }, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
+		add_settings_section(
+			'takamoa_papi_extra_section',
+			'Options supplémentaires',
+			null,
+			$this->plugin_name . '-settings'
+		);
+		
+		// Champs de redirection
+		add_settings_field('takamoa_papi_success_url', 'URL après succès', function () {
+			$default = home_url('/paiementreussi');
+			$value = esc_attr(get_option('takamoa_papi_success_url', $default));
+			echo "<input type='url' name='takamoa_papi_success_url' value='$value' style='width: 400px;'>";
+			echo "<p class='description'>Par défaut : <code>$default</code></p>";
+		}, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
 
-        add_settings_field('takamoa_papi_failure_url', 'URL après échec', function () {
-            $default = home_url('/paiementechoue');
-            $value = esc_attr(get_option('takamoa_papi_failure_url', $default));
-            echo "<input type='url' name='takamoa_papi_failure_url' value='$value' style='width: 400px;'>";
-            echo "<p class='description'>Par défaut : <code>$default</code></p>";
-        }, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
+		add_settings_field('takamoa_papi_failure_url', 'URL après échec', function () {
+			$default = home_url('/paiementechoue');
+			$value = esc_attr(get_option('takamoa_papi_failure_url', $default));
+			echo "<input type='url' name='takamoa_papi_failure_url' value='$value' style='width: 400px;'>";
+			echo "<p class='description'>Par défaut : <code>$default</code></p>";
+		}, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
 
-        // Durée de validité
-        add_settings_field('takamoa_papi_valid_duration', 'Durée de validité du lien (en minutes)', function () {
-            echo '<input type="number" name="takamoa_papi_valid_duration" value="' . esc_attr(get_option('takamoa_papi_valid_duration', 60)) . '" min="1">';
-        }, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
+		// Durée de validité
+		add_settings_field('takamoa_papi_valid_duration', 'Durée de validité du lien (en minutes)', function () {
+			echo '<input type="number" name="takamoa_papi_valid_duration" value="' . esc_attr(get_option('takamoa_papi_valid_duration', 60)) . '" min="1">';
+		}, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
 
-        // Méthodes de paiement
-        add_settings_field('takamoa_papi_providers', 'Méthodes de paiement disponibles', function () {
-            $active = (array) get_option('takamoa_papi_providers', []);
-            $providers = ['MVOLA' => 'MVOLA', 'ORANGE_MONEY' => 'Orange Money', 'AIRTEL_MONEY' => 'Airtel Money', 'BRED' => 'BRED'];
-            foreach ($providers as $key => $label) {
-                $checked = in_array($key, $active) ? 'checked' : '';
-                echo "<label><input type='checkbox' name='takamoa_papi_providers[]' value='$key' $checked> $label</label><br>";
-            }
-        }, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
+		// Méthodes de paiement
+		add_settings_field('takamoa_papi_providers', 'Méthodes de paiement disponibles', function () {
+			$active = (array) get_option('takamoa_papi_providers', []);
+			$providers = ['MVOLA' => 'MVOLA', 'ORANGE_MONEY' => 'Orange Money', 'AIRTEL_MONEY' => 'Airtel Money', 'BRED' => 'BRED'];
+			foreach ($providers as $key => $label) {
+				$checked = in_array($key, $active) ? 'checked' : '';
+				echo "<label><input type='checkbox' name='takamoa_papi_providers[]' value='$key' $checked> $label</label><br>";
+			}
+		}, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
 
-        // Champs visibles dans le formulaire
-        add_settings_field('takamoa_papi_optional_fields', 'Champs à afficher dans le formulaire', function () {
-            $fields = ['payerEmail' => 'Email client', 'payerPhone' => 'Téléphone client'];
-            $selected = (array) get_option('takamoa_papi_optional_fields', []);
-            foreach ($fields as $key => $label) {
-                $checked = in_array($key, $selected) ? 'checked' : '';
-                echo "<label><input type='checkbox' name='takamoa_papi_optional_fields[]' value='$key' $checked> $label</label><br>";
-            }
-        }, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
+		// Champs visibles dans le formulaire
+		add_settings_field('takamoa_papi_optional_fields', 'Champs à afficher dans le formulaire', function () {
+			$fields = ['payerEmail' => 'Email client', 'payerPhone' => 'Téléphone client'];
+			$selected = (array) get_option('takamoa_papi_optional_fields', []);
+			foreach ($fields as $key => $label) {
+				$checked = in_array($key, $selected) ? 'checked' : '';
+				echo "<label><input type='checkbox' name='takamoa_papi_optional_fields[]' value='$key' $checked> $label</label><br>";
+			}
+		}, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
 
-        // Test mode
-        add_settings_field('takamoa_papi_test_mode', 'Mode test (transactions réelles)', function () {
-            $checked = checked(get_option('takamoa_papi_test_mode', false), true, false);
-            echo "<input type='checkbox' name='takamoa_papi_test_mode' value='1' $checked> Activer le test mode";
-        }, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
+		// Test mode
+		add_settings_field('takamoa_papi_test_mode', 'Mode test (transactions réelles)', function () {
+			$checked = checked(get_option('takamoa_papi_test_mode', false), true, false);
+			echo "<input type='checkbox' name='takamoa_papi_test_mode' value='1' $checked> Activer le test mode";
+		}, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
 
-        add_settings_field('takamoa_papi_test_reason', 'Raison du test', function () {
-            echo '<input type="text" name="takamoa_papi_test_reason" value="' . esc_attr(get_option('takamoa_papi_test_reason')) . '" style="width: 400px;">';
-        }, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
-        
+		add_settings_field('takamoa_papi_test_reason', 'Raison du test', function () {
+			echo '<input type="text" name="takamoa_papi_test_reason" value="' . esc_attr(get_option('takamoa_papi_test_reason')) . '" style="width: 400px;">';
+		}, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
+		
 	}
 
 	/**
@@ -196,12 +196,12 @@ class Takamoa_Papi_Integration_Admin
 		<div class="wrap">
 			<h1><?php echo esc_html(get_admin_page_title()); ?></h1>
 			<form method="post" action="options.php">
-                <?php
-                settings_fields('takamoa_papi_key_group');
-                do_settings_sections($this->plugin_name); // clé API
-                submit_button();
-                ?>
-            </form>
+				<?php
+				settings_fields('takamoa_papi_key_group');
+				do_settings_sections($this->plugin_name); // clé API
+				submit_button();
+				?>
+			</form>
 		</div>
 		<?php
 	}
@@ -210,140 +210,140 @@ class Takamoa_Papi_Integration_Admin
 		// Optionnel : peut être utilisé plus tard pour des routes personnalisées
 	}
 
-    public function display_payments_page()
-    {
-        global $wpdb;
-        $table = $wpdb->prefix . 'takamoa_papi_payments';
-        $results = $wpdb->get_results("SELECT * FROM $table ORDER BY created_at DESC LIMIT 100");
-        ?>
-        <div class="wrap">
-            <h1>Historique des paiements</h1>
-            <table id="takamoa-payments-table" class="widefat striped">
-                <thead>
-                    <tr>
-                        <th>Référence</th>
-                        <th>Nom client</th>
-                        <th>Email</th>
-                        <th>Téléphone</th>
-                        <th>Montant</th>
-                        <th>Status</th>
-                        <th>Méthode</th>
-                        <th>Date</th>
-                        <th>Action</th>
-                    </tr>
-                </thead>
-                <tbody>
-                <?php foreach ($results as $row): ?>
-                    <tr class="payment-row"
-                        data-reference="<?= esc_attr($row->reference) ?>"
-                        data-client="<?= esc_attr($row->client_name) ?>"
-                        data-email="<?= esc_attr($row->payer_email) ?>"
-                        data-phone="<?= esc_attr($row->payer_phone) ?>"
-                        data-amount="<?= esc_attr(number_format($row->amount, 0, '', ' ') . ' MGA') ?>"
-                        data-status="<?= esc_attr($row->payment_status) ?>"
-                        data-method="<?= esc_attr($row->payment_method ?: '—') ?>"
-                        data-date="<?= esc_attr($row->created_at) ?>"
-                        data-description="<?= esc_attr($row->description) ?>"
-                        data-provider="<?= esc_attr($row->provider) ?>"
-                        data-success-url="<?= esc_attr($row->success_url) ?>"
-                        data-failure-url="<?= esc_attr($row->failure_url) ?>"
-                        data-notification-url="<?= esc_attr($row->notification_url) ?>"
-                        data-link-creation="<?= esc_attr($row->link_creation) ?>"
-                        data-link-expiration="<?= esc_attr($row->link_expiration) ?>"
-                        data-payment-link="<?= esc_attr($row->payment_link) ?>"
-                        data-currency="<?= esc_attr($row->currency) ?>"
-                        data-fee="<?= esc_attr($row->fee) ?>"
-                        data-notification-token="<?= esc_attr($row->notification_token) ?>"
-                        data-is-test-mode="<?= esc_attr($row->is_test_mode) ?>"
-                        data-test-reason="<?= esc_attr($row->test_reason) ?>"
-                        data-raw-request="<?= esc_attr($row->raw_request) ?>"
-                        data-raw-response="<?= esc_attr($row->raw_response) ?>"
-                        data-raw-notification="<?= esc_attr($row->raw_notification) ?>"
-                        data-updated-at="<?= esc_attr($row->updated_at) ?>"
-                        data-id="<?= esc_attr($row->id) ?>">
-                        <td><?= esc_html($row->reference) ?></td>
-                        <td><?= esc_html($row->client_name) ?></td>
-                        <td><?= esc_html($row->payer_email ?: '—') ?></td>
-                        <td><?= esc_html($row->payer_phone ?: '—') ?></td>
-                        <td><?= number_format($row->amount, 0, '', ' ') ?> MGA</td>
-                        <td><?= esc_html($row->payment_status) ?></td>
-                        <td><?= esc_html($row->payment_method ?: '—') ?></td>
-                        <td><?= esc_html($row->created_at) ?></td>
-                        <td><button type="button" class="button takamoa-notify">Notifier</button></td>
-                    </tr>
-                <?php endforeach; ?>
-                </tbody>
-            </table>
+	public function display_payments_page()
+	{
+		global $wpdb;
+		$table = $wpdb->prefix . 'takamoa_papi_payments';
+		$results = $wpdb->get_results("SELECT * FROM $table ORDER BY created_at DESC LIMIT 100");
+		?>
+		<div class="wrap">
+			<h1>Historique des paiements</h1>
+			<table id="takamoa-payments-table" class="widefat striped">
+				<thead>
+					<tr>
+						<th>Référence</th>
+						<th>Nom client</th>
+						<th>Email</th>
+						<th>Téléphone</th>
+						<th>Montant</th>
+						<th>Status</th>
+						<th>Méthode</th>
+						<th>Date</th>
+						<th>Action</th>
+					</tr>
+				</thead>
+				<tbody>
+				<?php foreach ($results as $row): ?>
+					<tr class="payment-row"
+						data-reference="<?= esc_attr($row->reference) ?>"
+						data-client="<?= esc_attr($row->client_name) ?>"
+						data-email="<?= esc_attr($row->payer_email) ?>"
+						data-phone="<?= esc_attr($row->payer_phone) ?>"
+						data-amount="<?= esc_attr(number_format($row->amount, 0, '', ' ') . ' MGA') ?>"
+						data-status="<?= esc_attr($row->payment_status) ?>"
+						data-method="<?= esc_attr($row->payment_method ?: '—') ?>"
+						data-date="<?= esc_attr($row->created_at) ?>"
+						data-description="<?= esc_attr($row->description) ?>"
+						data-provider="<?= esc_attr($row->provider) ?>"
+						data-success-url="<?= esc_attr($row->success_url) ?>"
+						data-failure-url="<?= esc_attr($row->failure_url) ?>"
+						data-notification-url="<?= esc_attr($row->notification_url) ?>"
+						data-link-creation="<?= esc_attr($row->link_creation) ?>"
+						data-link-expiration="<?= esc_attr($row->link_expiration) ?>"
+						data-payment-link="<?= esc_attr($row->payment_link) ?>"
+						data-currency="<?= esc_attr($row->currency) ?>"
+						data-fee="<?= esc_attr($row->fee) ?>"
+						data-notification-token="<?= esc_attr($row->notification_token) ?>"
+						data-is-test-mode="<?= esc_attr($row->is_test_mode) ?>"
+						data-test-reason="<?= esc_attr($row->test_reason) ?>"
+						data-raw-request="<?= esc_attr($row->raw_request) ?>"
+						data-raw-response="<?= esc_attr($row->raw_response) ?>"
+						data-raw-notification="<?= esc_attr($row->raw_notification) ?>"
+						data-updated-at="<?= esc_attr($row->updated_at) ?>"
+						data-id="<?= esc_attr($row->id) ?>">
+						<td><?= esc_html($row->reference) ?></td>
+						<td><?= esc_html($row->client_name) ?></td>
+						<td><?= esc_html($row->payer_email ?: '—') ?></td>
+						<td><?= esc_html($row->payer_phone ?: '—') ?></td>
+						<td><?= number_format($row->amount, 0, '', ' ') ?> MGA</td>
+						<td><?= esc_html($row->payment_status) ?></td>
+						<td><?= esc_html($row->payment_method ?: '—') ?></td>
+						<td><?= esc_html($row->created_at) ?></td>
+						<td><button type="button" class="button takamoa-notify">Notifier</button></td>
+					</tr>
+				<?php endforeach; ?>
+				</tbody>
+			</table>
 
-            <div class="modal fade" id="paymentModal" tabindex="-1" aria-hidden="true">
-                <div class="modal-dialog modal-dialog-centered modal-lg modal-fullscreen-sm-down">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <h5 class="modal-title">Détails du paiement</h5>
-                            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-                        </div>
-                        <div class="modal-body">
-                            <div class="table-responsive">
-                                <table class="table table-striped">
-                                    <tbody id="modal-basic-info">
-                                        <tr><th>ID</th><td id="modal-id"></td></tr>
-                                        <tr><th>Référence</th><td id="modal-reference"></td></tr>
-                                        <tr><th>Nom client</th><td id="modal-name"></td></tr>
-                                        <tr><th>Email</th><td id="modal-email"></td></tr>
-                                        <tr><th>Téléphone</th><td id="modal-phone"></td></tr>
-                                        <tr><th>Montant</th><td id="modal-amount"></td></tr>
-                                        <tr><th>Status</th><td id="modal-status"></td></tr>
-                                        <tr><th>Méthode</th><td id="modal-method"></td></tr>
-                                        <tr><th>Date</th><td id="modal-date"></td></tr>
-                                        <tr><th>Description</th><td id="modal-description"></td></tr>
-                                    </tbody>
-                                    <tbody id="modal-extra-info" class="d-none">
-                                        <tr><th>Provider</th><td id="modal-provider"></td></tr>
-                                        <tr><th>Success URL</th><td id="modal-success-url"></td></tr>
-                                        <tr><th>Failure URL</th><td id="modal-failure-url"></td></tr>
-                                        <tr><th>Notification URL</th><td id="modal-notification-url"></td></tr>
-                                        <tr><th>Link creation</th><td id="modal-link-creation"></td></tr>
-                                        <tr><th>Link expiration</th><td id="modal-link-expiration"></td></tr>
-                                        <tr><th>Payment link</th><td id="modal-payment-link"></td></tr>
-                                        <tr><th>Currency</th><td id="modal-currency"></td></tr>
-                                        <tr><th>Fee</th><td id="modal-fee"></td></tr>
-                                        <tr><th>Notification token</th><td id="modal-notification-token"></td></tr>
-                                        <tr><th>Test mode</th><td id="modal-test-mode"></td></tr>
-                                        <tr><th>Test reason</th><td id="modal-test-reason"></td></tr>
-                                        <tr><th>Raw request</th><td><pre id="modal-raw-request" class="mb-0"></pre></td></tr>
-                                        <tr><th>Raw response</th><td><pre id="modal-raw-response" class="mb-0"></pre></td></tr>
-                                        <tr><th>Raw notification</th><td><pre id="modal-raw-notification" class="mb-0"></pre></td></tr>
-                                        <tr><th>Updated at</th><td id="modal-updated-at"></td></tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                        <div class="modal-footer">
-                            <button type="button" class="btn btn-outline-primary" id="toggle-more-info">Show more</button>
-                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <?php
-    }
+			<div class="modal fade" id="paymentModal" tabindex="-1" aria-hidden="true">
+				<div class="modal-dialog modal-dialog-centered modal-lg modal-fullscreen-sm-down">
+					<div class="modal-content">
+						<div class="modal-header">
+							<h5 class="modal-title">Détails du paiement</h5>
+							<button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+						</div>
+						<div class="modal-body">
+							<div class="table-responsive">
+								<table class="table table-striped">
+									<tbody id="modal-basic-info">
+										<tr><th>ID</th><td id="modal-id"></td></tr>
+										<tr><th>Référence</th><td id="modal-reference"></td></tr>
+										<tr><th>Nom client</th><td id="modal-name"></td></tr>
+										<tr><th>Email</th><td id="modal-email"></td></tr>
+										<tr><th>Téléphone</th><td id="modal-phone"></td></tr>
+										<tr><th>Montant</th><td id="modal-amount"></td></tr>
+										<tr><th>Status</th><td id="modal-status"></td></tr>
+										<tr><th>Méthode</th><td id="modal-method"></td></tr>
+										<tr><th>Date</th><td id="modal-date"></td></tr>
+										<tr><th>Description</th><td id="modal-description"></td></tr>
+									</tbody>
+									<tbody id="modal-extra-info" class="d-none">
+										<tr><th>Provider</th><td id="modal-provider"></td></tr>
+										<tr><th>Success URL</th><td id="modal-success-url"></td></tr>
+										<tr><th>Failure URL</th><td id="modal-failure-url"></td></tr>
+										<tr><th>Notification URL</th><td id="modal-notification-url"></td></tr>
+										<tr><th>Link creation</th><td id="modal-link-creation"></td></tr>
+										<tr><th>Link expiration</th><td id="modal-link-expiration"></td></tr>
+										<tr><th>Payment link</th><td id="modal-payment-link"></td></tr>
+										<tr><th>Currency</th><td id="modal-currency"></td></tr>
+										<tr><th>Fee</th><td id="modal-fee"></td></tr>
+										<tr><th>Notification token</th><td id="modal-notification-token"></td></tr>
+										<tr><th>Test mode</th><td id="modal-test-mode"></td></tr>
+										<tr><th>Test reason</th><td id="modal-test-reason"></td></tr>
+										<tr><th>Raw request</th><td><pre id="modal-raw-request" class="mb-0"></pre></td></tr>
+										<tr><th>Raw response</th><td><pre id="modal-raw-response" class="mb-0"></pre></td></tr>
+										<tr><th>Raw notification</th><td><pre id="modal-raw-notification" class="mb-0"></pre></td></tr>
+										<tr><th>Updated at</th><td id="modal-updated-at"></td></tr>
+									</tbody>
+								</table>
+							</div>
+						</div>
+						<div class="modal-footer">
+							<button type="button" class="btn btn-outline-primary" id="toggle-more-info">Show more</button>
+							<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
 
-    public function display_options_page()
-    {
-        ?>
-        <div class="wrap">
-            <h1>Options avancées</h1>
-            <form method="post" action="options.php">
-                <?php
-                settings_fields('takamoa_papi_settings_group');
-                do_settings_sections($this->plugin_name . '-settings');
-                submit_button();
-                ?>
-            </form>
-        </div>
-        <?php
-    }
+	public function display_options_page()
+	{
+		?>
+		<div class="wrap">
+			<h1>Options avancées</h1>
+			<form method="post" action="options.php">
+				<?php
+				settings_fields('takamoa_papi_settings_group');
+				do_settings_sections($this->plugin_name . '-settings');
+				submit_button();
+				?>
+			</form>
+		</div>
+		<?php
+	}
 
 
 }

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -56,4 +56,22 @@ jQuery(document).ready(function($) {
         $('#modal-extra-info').toggleClass('d-none');
         $(this).text($('#modal-extra-info').hasClass('d-none') ? 'Show more' : 'Show less');
     });
+
+    $(document).on('click', '.takamoa-notify', function(e) {
+        e.stopPropagation();
+        var btn = $(this);
+        var row = btn.closest('tr');
+        btn.prop('disabled', true);
+        $.post(takamoaAjax.ajaxurl, {
+            action: 'takamoa_resend_payment_email',
+            nonce: takamoaAjax.nonce,
+            reference: row.data('reference')
+        }).done(function(res) {
+            alert(res.data && res.data.message ? res.data.message : 'Notification envoyée');
+        }).fail(function() {
+            alert('Erreur lors de l\'envoi de la notification');
+        }).always(function(){
+            btn.prop('disabled', false);
+        });
+    });
 });

--- a/includes/class-takamoa-papi-integration-functions.php
+++ b/includes/class-takamoa-papi-integration-functions.php
@@ -21,47 +21,47 @@
  */
 class Takamoa_Papi_Integration_Functions {
 
-        private function send_registration_email($email, $name, $link) {
-                if (empty($email)) {
-                        return;
-                }
+		private function send_registration_email($email, $name, $link) {
+				if (empty($email)) {
+						return;
+				}
 
-                $subject = "Confirmation d'inscription et modalités de paiement";
+				$subject = "Confirmation d'inscription et modalités de paiement";
 
-                $message  = '<p>Bonjour ' . esc_html($name) . ',</p>';
-                $message .= '<p>Nous vous confirmons que votre inscription a bien été enregistrée.</p>';
-                $message .= '<p>Pour réserver définitivement votre place et finaliser votre paiement, veuillez cliquer sur le bouton ci-dessous :</p>';
-                $message .= '<p><a href="' . esc_url($link) . '" style="display:inline-block;padding:10px 20px;background:#0073aa;color:#fff;text-decoration:none;">Réserver et payer</a></p>';
-                $message .= '<p>Pour toute question ou précision, notre équipe logistique se tient à votre disposition au 034 04 105 06.</p>';
-                $message .= '<p>Bien cordialement,<br>L’équipe logistique</p>';
-                $logo = get_site_icon_url();
-                if ($logo) {
-                        $message .= '<p><img src="' . esc_url($logo) . '" alt="Logo" style="max-width:150px;height:auto;"></p>';
-                }
+				$message  = '<p>Bonjour ' . esc_html($name) . ',</p>';
+				$message .= '<p>Nous vous confirmons que votre inscription a bien été enregistrée.</p>';
+				$message .= '<p>Pour réserver définitivement votre place et finaliser votre paiement, veuillez cliquer sur le bouton ci-dessous :</p>';
+				$message .= '<p><a href="' . esc_url($link) . '" style="display:inline-block;padding:10px 20px;background:#0073aa;color:#fff;text-decoration:none;">Réserver et payer</a></p>';
+				$message .= '<p>Pour toute question ou précision, notre équipe logistique se tient à votre disposition au 034 04 105 06.</p>';
+				$message .= '<p>Bien cordialement,<br>L’équipe logistique</p>';
+				$logo = get_site_icon_url();
+				if ($logo) {
+						$message .= '<p><img src="' . esc_url($logo) . '" alt="Logo" style="max-width:150px;height:auto;"></p>';
+				}
 
-                $headers = ['Content-Type: text/html; charset=UTF-8'];
-                wp_mail($email, $subject, $message, $headers);
-        }
+				$headers = ['Content-Type: text/html; charset=UTF-8'];
+				wp_mail($email, $subject, $message, $headers);
+		}
 
-        private function send_payment_success_email($email, $name) {
-                if (empty($email)) {
-                        return;
-                }
+		private function send_payment_success_email($email, $name) {
+				if (empty($email)) {
+						return;
+				}
 
-                $subject = 'Confirmation de paiement';
+				$subject = 'Confirmation de paiement';
 
-                $message  = '<p>Bonjour ' . esc_html($name) . ',</p>';
-                $message .= '<p>Nous vous confirmons que votre paiement a bien été reçu. Merci pour votre inscription.</p>';
-                $message .= '<p>Pour toute question ou précision, notre équipe logistique se tient à votre disposition au 034 04 105 06.</p>';
-                $message .= '<p>Bien cordialement,<br>L’équipe logistique</p>';
-                $logo = get_site_icon_url();
-                if ($logo) {
-                        $message .= '<p><img src="' . esc_url($logo) . '" alt="Logo" style="max-width:150px;height:auto;"></p>';
-                }
+				$message  = '<p>Bonjour ' . esc_html($name) . ',</p>';
+				$message .= '<p>Nous vous confirmons que votre paiement a bien été reçu. Merci pour votre inscription.</p>';
+				$message .= '<p>Pour toute question ou précision, notre équipe logistique se tient à votre disposition au 034 04 105 06.</p>';
+				$message .= '<p>Bien cordialement,<br>L’équipe logistique</p>';
+				$logo = get_site_icon_url();
+				if ($logo) {
+						$message .= '<p><img src="' . esc_url($logo) . '" alt="Logo" style="max-width:150px;height:auto;"></p>';
+				}
 
-                $headers = ['Content-Type: text/html; charset=UTF-8'];
-                wp_mail($email, $subject, $message, $headers);
-        }
+				$headers = ['Content-Type: text/html; charset=UTF-8'];
+				wp_mail($email, $subject, $message, $headers);
+		}
 
 	public function register_endpoints() {
 		add_rewrite_endpoint('paiementreussi', EP_ROOT);
@@ -119,171 +119,171 @@ class Takamoa_Papi_Integration_Functions {
 			return;
 		}
 
-                $status = sanitize_text_field($body['paymentStatus']);
+				$status = sanitize_text_field($body['paymentStatus']);
 
-                $wpdb->update($table, [
-                        'payment_status'   => $status,
-                        'payment_method'   => sanitize_text_field($body['paymentMethod']),
-                        'currency'         => sanitize_text_field($body['currency']),
-                        'fee'              => floatval($body['fee']),
-                        'raw_notification' => json_encode($body),
-                        'updated_at'       => current_time('mysql')
-                ], ['id' => $payment->id]);
+				$wpdb->update($table, [
+						'payment_status'   => $status,
+						'payment_method'   => sanitize_text_field($body['paymentMethod']),
+						'currency'         => sanitize_text_field($body['currency']),
+						'fee'              => floatval($body['fee']),
+						'raw_notification' => json_encode($body),
+						'updated_at'       => current_time('mysql')
+				], ['id' => $payment->id]);
 
-                if ($status === 'SUCCESS') {
-                        $this->send_payment_success_email($payment->payer_email, $payment->client_name);
-                }
+				if ($status === 'SUCCESS') {
+						$this->send_payment_success_email($payment->payer_email, $payment->client_name);
+				}
 
-                status_header(200);
-                echo json_encode(['success' => true]);
-        }
+				status_header(200);
+				echo json_encode(['success' => true]);
+		}
 
-    public function handle_create_payment_ajax() {
-        check_ajax_referer('takamoa_papi_nonce');
-    
-        // Vérifie les données
-        $clientName  = sanitize_text_field($_POST['clientName'] ?? '');
-        $amount      = floatval($_POST['amount'] ?? 0);
-        $reference   = sanitize_text_field($_POST['reference'] ?? '');
-        $payerEmail  = sanitize_email($_POST['payerEmail'] ?? '');
-        $payerPhone  = sanitize_text_field($_POST['payerPhone'] ?? '');
-        $description = sanitize_text_field($_POST['description'] ?? '');
-        $provider    = sanitize_text_field($_POST['provider'] ?? '');
+	public function handle_create_payment_ajax() {
+		check_ajax_referer('takamoa_papi_nonce');
+	
+		// Vérifie les données
+		$clientName  = sanitize_text_field($_POST['clientName'] ?? '');
+		$amount      = floatval($_POST['amount'] ?? 0);
+		$reference   = sanitize_text_field($_POST['reference'] ?? '');
+		$payerEmail  = sanitize_email($_POST['payerEmail'] ?? '');
+		$payerPhone  = sanitize_text_field($_POST['payerPhone'] ?? '');
+		$description = sanitize_text_field($_POST['description'] ?? '');
+		$provider    = sanitize_text_field($_POST['provider'] ?? '');
 
-        if ($amount < 300 || !$clientName || !$reference) {
-            wp_send_json_error(['message' => 'Champs requis manquants ou invalides.']);
-        }
+		if ($amount < 300 || !$clientName || !$reference) {
+			wp_send_json_error(['message' => 'Champs requis manquants ou invalides.']);
+		}
 
-        // Récupère les options admin
-        $api_key        = get_option('takamoa_papi_api_key');
-        $successUrl     = get_option('takamoa_papi_success_url', home_url('/paiementreussi'));
-        $failureUrl     = get_option('takamoa_papi_failure_url', home_url('/paiementechoue'));
-        $notificationUrl = home_url('/papi-notify');
-        $validDuration  = intval(get_option('takamoa_papi_valid_duration', 60));
-        $isTestMode     = (bool) get_option('takamoa_papi_test_mode', false);
-        $testReason     = sanitize_text_field(get_option('takamoa_papi_test_reason', ''));
+		// Récupère les options admin
+		$api_key        = get_option('takamoa_papi_api_key');
+		$successUrl     = get_option('takamoa_papi_success_url', home_url('/paiementreussi'));
+		$failureUrl     = get_option('takamoa_papi_failure_url', home_url('/paiementechoue'));
+		$notificationUrl = home_url('/papi-notify');
+		$validDuration  = intval(get_option('takamoa_papi_valid_duration', 60));
+		$isTestMode     = (bool) get_option('takamoa_papi_test_mode', false);
+		$testReason     = sanitize_text_field(get_option('takamoa_papi_test_reason', ''));
 
-        // Construction du corps de la requête
-        $request = [
-            'clientName'      => $clientName,
-            'amount'          => $amount,
-            'reference'       => $reference,
-            'description'     => $description ?: 'Paiement via Papi',
-            'payerEmail'      => $payerEmail,
-            'payerPhone'      => $payerPhone,
-            'notificationUrl' => $notificationUrl,
-            'validDuration'   => $validDuration,
-            'isTestMode'      => $isTestMode,
-            'testReason'      => $isTestMode ? $testReason : ''
-        ];
+		// Construction du corps de la requête
+		$request = [
+			'clientName'      => $clientName,
+			'amount'          => $amount,
+			'reference'       => $reference,
+			'description'     => $description ?: 'Paiement via Papi',
+			'payerEmail'      => $payerEmail,
+			'payerPhone'      => $payerPhone,
+			'notificationUrl' => $notificationUrl,
+			'validDuration'   => $validDuration,
+			'isTestMode'      => $isTestMode,
+			'testReason'      => $isTestMode ? $testReason : ''
+		];
 
-        if (!empty($provider)) {
-            $request['provider'] = $provider;
-        }
-        if (!empty($successUrl)) {
-            $request['successUrl'] = $successUrl;
-        }
-        if (!empty($failureUrl)) {
-            $request['failureUrl'] = $failureUrl;
-        }
+		if (!empty($provider)) {
+			$request['provider'] = $provider;
+		}
+		if (!empty($successUrl)) {
+			$request['successUrl'] = $successUrl;
+		}
+		if (!empty($failureUrl)) {
+			$request['failureUrl'] = $failureUrl;
+		}
 
-        $response = wp_remote_post('https://app.papi.mg/dashboard/api/payment-links', [
-            'headers' => [
-                'Token' => $api_key,
-                'Content-Type' => 'application/json',
-            ],
-            'body' => json_encode($request)
-        ]);
+		$response = wp_remote_post('https://app.papi.mg/dashboard/api/payment-links', [
+			'headers' => [
+				'Token' => $api_key,
+				'Content-Type' => 'application/json',
+			],
+			'body' => json_encode($request)
+		]);
 
-        if (is_wp_error($response)) {
-            wp_send_json_error(['message' => 'Erreur de connexion à Papi.']);
-        }
+		if (is_wp_error($response)) {
+			wp_send_json_error(['message' => 'Erreur de connexion à Papi.']);
+		}
 
-        $body = json_decode(wp_remote_retrieve_body($response), true);
+		$body = json_decode(wp_remote_retrieve_body($response), true);
 
-        if (!isset($body['data']['paymentLink'])) {
-            wp_send_json_error(['message' => $body['error']['message'] ?? 'Erreur inconnue.']);
-        }
+		if (!isset($body['data']['paymentLink'])) {
+			wp_send_json_error(['message' => $body['error']['message'] ?? 'Erreur inconnue.']);
+		}
 
-        $link = esc_url($body['data']['paymentLink']);
+		$link = esc_url($body['data']['paymentLink']);
 
-        // Sauvegarde dans la base
-        global $wpdb;
-        $table = $wpdb->prefix . 'takamoa_papi_payments';
-        $payment_method = !empty($provider) ? $provider : '—';
-        $wpdb->insert($table, [
-            'reference'          => $reference,
-            'client_name'        => $clientName,
-            'amount'             => $amount,
-            'description'        => $request['description'],
-            'payer_email'        => $payerEmail,
-            'payer_phone'        => $payerPhone,
-            'provider'           => $provider,
-            'success_url'        => $successUrl,
-            'failure_url'        => $failureUrl,
-            'notification_url'   => $notificationUrl,
-            'link_creation'      => current_time('mysql'),
-            'payment_link'       => $link,
-            'payment_status'     => 'PENDING',
+		// Sauvegarde dans la base
+		global $wpdb;
+		$table = $wpdb->prefix . 'takamoa_papi_payments';
+		$payment_method = !empty($provider) ? $provider : '—';
+		$wpdb->insert($table, [
+			'reference'          => $reference,
+			'client_name'        => $clientName,
+			'amount'             => $amount,
+			'description'        => $request['description'],
+			'payer_email'        => $payerEmail,
+			'payer_phone'        => $payerPhone,
+			'provider'           => $provider,
+			'success_url'        => $successUrl,
+			'failure_url'        => $failureUrl,
+			'notification_url'   => $notificationUrl,
+			'link_creation'      => current_time('mysql'),
+			'payment_link'       => $link,
+			'payment_status'     => 'PENDING',
 			'payment_method'     => $payment_method,
-            'notification_token' => $body['data']['notificationToken'] ?? '',
-            'is_test_mode'       => $isTestMode,
-            'test_reason'        => $testReason,
-            'raw_request'        => json_encode($request),
-            'raw_response'       => json_encode($body),
-        ]);
+			'notification_token' => $body['data']['notificationToken'] ?? '',
+			'is_test_mode'       => $isTestMode,
+			'test_reason'        => $testReason,
+			'raw_request'        => json_encode($request),
+			'raw_response'       => json_encode($body),
+		]);
 
-        if ($payerEmail) {
-            $this->send_registration_email($payerEmail, $clientName, $link);
-        }
+		if ($payerEmail) {
+			$this->send_registration_email($payerEmail, $clientName, $link);
+		}
 
-        wp_send_json_success(['link' => $link]);
-    }
+		wp_send_json_success(['link' => $link]);
+	}
 
-    public function handle_check_payment_status_ajax() {
-        check_ajax_referer('takamoa_papi_nonce');
-    
-        $reference = sanitize_text_field($_POST['reference'] ?? '');
-    
-        if (!$reference) {
-            wp_send_json_error(['message' => 'Référence manquante.']);
-        }
-    
-        global $wpdb;
-        $table = $wpdb->prefix . 'takamoa_papi_payments';
-    
-        $status = $wpdb->get_var($wpdb->prepare("SELECT payment_status FROM $table WHERE reference = %s LIMIT 1", $reference));
-    
-        if (!$status) {
-            wp_send_json_error(['message' => 'Paiement introuvable.']);
-        }
-    
-        wp_send_json_success(['status' => $status]);
-    }
+	public function handle_check_payment_status_ajax() {
+		check_ajax_referer('takamoa_papi_nonce');
+	
+		$reference = sanitize_text_field($_POST['reference'] ?? '');
+	
+		if (!$reference) {
+			wp_send_json_error(['message' => 'Référence manquante.']);
+		}
+	
+		global $wpdb;
+		$table = $wpdb->prefix . 'takamoa_papi_payments';
+	
+		$status = $wpdb->get_var($wpdb->prepare("SELECT payment_status FROM $table WHERE reference = %s LIMIT 1", $reference));
+	
+		if (!$status) {
+			wp_send_json_error(['message' => 'Paiement introuvable.']);
+		}
+	
+		wp_send_json_success(['status' => $status]);
+	}
 
-    public function handle_resend_payment_email_ajax() {
-        check_ajax_referer('takamoa_papi_nonce', 'nonce');
+	public function handle_resend_payment_email_ajax() {
+		check_ajax_referer('takamoa_papi_nonce', 'nonce');
 
-        if (!current_user_can('manage_options')) {
-            wp_send_json_error(['message' => 'Unauthorized'], 403);
-        }
+		if (!current_user_can('manage_options')) {
+			wp_send_json_error(['message' => 'Unauthorized'], 403);
+		}
 
-        $reference = sanitize_text_field($_POST['reference'] ?? '');
-        if (!$reference) {
-            wp_send_json_error(['message' => 'Référence manquante.']);
-        }
+		$reference = sanitize_text_field($_POST['reference'] ?? '');
+		if (!$reference) {
+			wp_send_json_error(['message' => 'Référence manquante.']);
+		}
 
-        global $wpdb;
-        $table = $wpdb->prefix . 'takamoa_papi_payments';
-        $payment = $wpdb->get_row($wpdb->prepare("SELECT client_name, payer_email, payment_link FROM $table WHERE reference = %s LIMIT 1", $reference));
+		global $wpdb;
+		$table = $wpdb->prefix . 'takamoa_papi_payments';
+		$payment = $wpdb->get_row($wpdb->prepare("SELECT client_name, payer_email, payment_link FROM $table WHERE reference = %s LIMIT 1", $reference));
 
-        if (!$payment || empty($payment->payer_email)) {
-            wp_send_json_error(['message' => 'Paiement introuvable.']);
-        }
+		if (!$payment || empty($payment->payer_email)) {
+			wp_send_json_error(['message' => 'Paiement introuvable.']);
+		}
 
-        $this->send_registration_email($payment->payer_email, $payment->client_name, $payment->payment_link);
+		$this->send_registration_email($payment->payer_email, $payment->client_name, $payment->payment_link);
 
-        wp_send_json_success(['message' => 'Notification envoyée.']);
-    }
-    
+		wp_send_json_success(['message' => 'Notification envoyée.']);
+	}
+	
 }

--- a/includes/class-takamoa-papi-integration.php
+++ b/includes/class-takamoa-papi-integration.php
@@ -34,7 +34,7 @@ class Takamoa_Papi_Integration {
 	 * @access   protected
 	 * @var      Takamoa_Papi_Integration_Loader    $loader    Maintains and registers all hooks for the plugin.
 	 */
-    protected $loader;
+	protected $loader;
 
 	/**
 	 * The unique identifier of this plugin.
@@ -43,7 +43,7 @@ class Takamoa_Papi_Integration {
 	 * @access   protected
 	 * @var      string    $plugin_name    The string used to uniquely identify this plugin.
 	 */
-    protected $plugin_name;
+	protected $plugin_name;
 
 	/**
 	 * The current version of the plugin.
@@ -53,7 +53,7 @@ class Takamoa_Papi_Integration {
 	 * @var      string    $version    The current version of the plugin.
 	 */
 
-    protected $version;
+	protected $version;
 
 	/**
 	 * Functions of the plugin.
@@ -63,7 +63,7 @@ class Takamoa_Papi_Integration {
 	 * @var      Takamoa_Papi_Integration_Functions    $functions
 	 */
 	 
-    protected $functions;
+	protected $functions;
 
 	/**
 	 * Define the core functionality of the plugin.
@@ -107,18 +107,18 @@ class Takamoa_Papi_Integration {
 	 * @access   private
 	 */
 
-    private function load_dependencies() {
+	private function load_dependencies() {
 		/**
 		 * The class responsible for providing functions of the
 		 * core plugin.
 		*/	
-        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-takamoa-papi-integration-functions.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-takamoa-papi-integration-functions.php';
 		/**
 		 * The class responsible for orchestrating the actions and filters of the
 		 * core plugin.
 		*/		
-        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-takamoa-papi-integration-loader.php';
-        
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-takamoa-papi-integration-loader.php';
+		
 		/**
 		 * The class responsible for defining internationalization functionality
 		 * of the plugin.
@@ -128,17 +128,17 @@ class Takamoa_Papi_Integration {
 		/**
 		 * The class responsible for defining all actions that occur in the admin area.
 		 */
-        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-takamoa-papi-integration-admin.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-takamoa-papi-integration-admin.php';
 
 		/**
 		 * The class responsible for defining all actions that occur in the public-facing
 		 * side of the site.
 		 */		
-        require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-takamoa-papi-integration-public.php';
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-takamoa-papi-integration-public.php';
 
-        $this->loader = new Takamoa_Papi_Integration_Loader();
-        $this->functions = new Takamoa_Papi_Integration_Functions();
-    }
+		$this->loader = new Takamoa_Papi_Integration_Loader();
+		$this->functions = new Takamoa_Papi_Integration_Functions();
+	}
 
 	/**
 	 * Define the locale for this plugin for internationalization.
@@ -171,10 +171,10 @@ class Takamoa_Papi_Integration {
 
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
-                $this->loader->add_action('admin_menu', $plugin_admin, 'add_menu');
-                $this->loader->add_action('admin_init', $plugin_admin, 'register_settings');
-                $this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
-        }
+		$this->loader->add_action('admin_menu', $plugin_admin, 'add_menu');
+		$this->loader->add_action('admin_init', $plugin_admin, 'register_settings');
+		$this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
+		}
 
 	/**
 	 * Register all of the hooks related to the public-facing functionality
@@ -183,7 +183,7 @@ class Takamoa_Papi_Integration {
 	 * @since    0.0.1
 	 * @access   private
 	 */	
-    private function define_public_hooks() {
+	private function define_public_hooks() {
 
 		$plugin_public = new Takamoa_Papi_Integration_Public( $this->get_plugin_name(), $this->get_version(), $this->get_functions() );
 
@@ -205,9 +205,9 @@ class Takamoa_Papi_Integration {
 	 */
 	public function run() {
 		$this->loader->run();
-        
+		
 	}
-    
+	
 
 	/**
 	 * The name of the plugin used to uniquely identify it within the context of

--- a/includes/class-takamoa-papi-integration.php
+++ b/includes/class-takamoa-papi-integration.php
@@ -171,9 +171,10 @@ class Takamoa_Papi_Integration {
 
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
-		$this->loader->add_action('admin_menu', $plugin_admin, 'add_menu');
-		$this->loader->add_action('admin_init', $plugin_admin, 'register_settings');
-	}
+                $this->loader->add_action('admin_menu', $plugin_admin, 'add_menu');
+                $this->loader->add_action('admin_init', $plugin_admin, 'register_settings');
+                $this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
+        }
 
 	/**
 	 * Register all of the hooks related to the public-facing functionality


### PR DESCRIPTION
## Summary
- send registration confirmation email with updated payment instructions
- send thank-you email when payment confirmed using same format
- add admin "Notifier" action to resend registration email

## Testing
- `php -l includes/class-takamoa-papi-integration-functions.php`
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l includes/class-takamoa-papi-integration.php`
- `node --check admin/js/takamoa-papi-integration-admin.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689ca7ea039c832eab2e3dceac404261