### PR TITLE
fix: ensure logo uses https in emails

### DIFF
--- a/includes/class-takamoa-papi-integration-functions.php
+++ b/includes/class-takamoa-papi-integration-functions.php
@@ -36,6 +36,7 @@ class Takamoa_Papi_Integration_Functions {
 				$message .= '<p>Bien cordialement,<br>L’équipe logistique</p>';
 				$logo = get_site_icon_url();
 				if ($logo) {
+						$logo = set_url_scheme($logo, 'https');
 						$message .= '<p><img src="' . esc_url($logo) . '" alt="Logo" style="max-width:150px;height:auto;"></p>';
 				}
 
@@ -56,6 +57,7 @@ class Takamoa_Papi_Integration_Functions {
 				$message .= '<p>Bien cordialement,<br>L’équipe logistique</p>';
 				$logo = get_site_icon_url();
 				if ($logo) {
+						$logo = set_url_scheme($logo, 'https');
 						$message .= '<p><img src="' . esc_url($logo) . '" alt="Logo" style="max-width:150px;height:auto;"></p>';
 				}
 


### PR DESCRIPTION
## Summary
- enforce https scheme for site icon in notification emails

## Testing
- `php -l includes/class-takamoa-papi-integration-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_689cb5d0a69c832e81fa3490a58bc662