### PR TITLE
Add payment option to takamoa_papi_form shortcode

### DIFF
--- a/public/class-takamoa-papi-integration-public.php
+++ b/public/class-takamoa-papi-integration-public.php
@@ -101,11 +101,15 @@ class Takamoa_Papi_Integration_Public {
 	/**
 	 * Shortcode qui affiche le conteneur Vue.js
 	 */
-	public function render_vue_form_shortcode($atts) {
-		$atts = shortcode_atts([
-			'amount' => '',
-			'reference' => ''
-		], $atts);
+        public function render_vue_form_shortcode($atts) {
+                $atts = shortcode_atts([
+                        'amount' => '',
+                        'reference' => '',
+                        'payment' => 'yes'
+                ], $atts);
+
+                // Assure que le paramètre payment n'accepte que 'yes' ou 'no'
+                $atts['payment'] = in_array($atts['payment'], ['yes', 'no'], true) ? $atts['payment'] : 'yes';
 	
 		$timestamp = time();
 	
@@ -124,11 +128,12 @@ class Takamoa_Papi_Integration_Public {
 	
 		ob_start();
 		?>
-		<div id="<?php echo esc_attr($uid); ?>"
-			 class="takamoa-papi-app"
-			 data-amount="<?php echo esc_attr($atts['amount']); ?>"
-			 data-reference="<?php echo esc_attr($atts['reference']); ?>">
-		</div>
+                <div id="<?php echo esc_attr($uid); ?>"
+                         class="takamoa-papi-app"
+                         data-amount="<?php echo esc_attr($atts['amount']); ?>"
+                         data-reference="<?php echo esc_attr($atts['reference']); ?>"
+                         data-payment="<?php echo esc_attr($atts['payment']); ?>">
+                </div>
 		<?php
 		return ob_get_clean();
 	}

--- a/public/js/takamoa-papi-form.js
+++ b/public/js/takamoa-papi-form.js
@@ -1,24 +1,25 @@
 const appRoot = document.getElementById('takamoa-papi-app');
 
 document.querySelectorAll('.takamoa-papi-app').forEach((el, index) => {
-	new Vue({
-		el,
-		data: {
+        new Vue({
+                el,
+                data: {
             clientFirstName: '',
-	        clientLastName: '',
-			amount: el.dataset.amount || '',
-			reference: el.dataset.reference || '',
-			payerEmail: '',
-			payerPhone: '',
-			description: '',
-			provider: '',
-			loading: false,
-			link: '',
-			status: '',
-			error: '',
-			success: '',
-			polling: null
-		},
+                clientLastName: '',
+                        amount: el.dataset.amount || '',
+                        reference: el.dataset.reference || '',
+                        payment: el.dataset.payment === 'no' ? 'no' : 'yes',
+                        payerEmail: '',
+                        payerPhone: '',
+                        description: '',
+                        provider: '',
+                        loading: false,
+                        link: '',
+                        status: '',
+                        error: '',
+                        success: '',
+                        polling: null
+                },
 		computed: {
             clientName() {
                 return `${this.clientFirstName} ${this.clientLastName}`.trim();
@@ -36,49 +37,55 @@ document.querySelectorAll('.takamoa-papi-app').forEach((el, index) => {
 			}
 		},
 		methods: {
-			submitForm() {
-				this.loading = true;
-				this.error = '';
-				this.link = '';
-				this.success = '';
-				this.status = '';
+                        submitForm() {
+                                this.loading = true;
+                                this.error = '';
+                                this.link = '';
+                                this.success = '';
+                                this.status = '';
 
-				const data = {
-					action: 'takamoa_create_payment',
-					_ajax_nonce: TakamoaPapiVars.api_nonce,
-					clientName: this.clientName,
-					amount: this.amount,
-					reference: this.reference,
-					payerEmail: this.payerEmail,
-					payerPhone: this.payerPhone,
-					description: this.description
-				};
+                                if (this.payment === 'no') {
+                                        this.success = 'Merci pour votre inscription.';
+                                        this.loading = false;
+                                        return;
+                                }
+
+                                const data = {
+                                        action: 'takamoa_create_payment',
+                                        _ajax_nonce: TakamoaPapiVars.api_nonce,
+                                        clientName: this.clientName,
+                                        amount: this.amount,
+                                        reference: this.reference,
+                                        payerEmail: this.payerEmail,
+                                        payerPhone: this.payerPhone,
+                                        description: this.description
+                                };
 
                 if (this.provider) {
-					data.provider = this.provider;
-				}
+                                        data.provider = this.provider;
+                                }
 
-				fetch(TakamoaPapiVars.ajax_url, {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-					body: new URLSearchParams(data)
-				})
-				.then(res => res.json())
-				.then(res => {
-					if (res.success && res.data.link) {
-						this.link = res.data.link;
-						window.open(this.link, '_blank');
+                                fetch(TakamoaPapiVars.ajax_url, {
+                                        method: 'POST',
+                                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                                        body: new URLSearchParams(data)
+                                })
+                                .then(res => res.json())
+                                .then(res => {
+                                        if (res.success && res.data.link) {
+                                                this.link = res.data.link;
+                                                window.open(this.link, '_blank');
                         this.polling = setInterval(this.checkStatus, 2000);
-					} else {
-						this.error = res.data?.message || 'Erreur';
-						this.loading = false;
-					}
-				})
-				.catch(() => {
-					this.loading = false;
-					this.error = 'Erreur réseau. Veuillez réessayer.';
-				});
-			},
+                                        } else {
+                                                this.error = res.data?.message || 'Erreur';
+                                                this.loading = false;
+                                        }
+                                })
+                                .catch(() => {
+                                        this.loading = false;
+                                        this.error = 'Erreur réseau. Veuillez réessayer.';
+                                });
+                        },
 			checkStatus() {
                 if (!this.reference) return;
             
@@ -119,9 +126,9 @@ document.querySelectorAll('.takamoa-papi-app').forEach((el, index) => {
                 });
             }
 		},
-		template: `
+                template: `
             <div class="takamoa-papi-form" :class="{ 'is-loading': loading }">
-				<div class="takamoa-papi-loading-overlay" v-if="loading">
+                                <div class="takamoa-papi-loading-overlay" v-if="loading && payment === 'yes'">
                     <div class="spinner"></div>
                     <p v-if="link" class="takamoa-papi-message">
                         Félicitations ! Vous êtes inscrit.<br>


### PR DESCRIPTION
## Summary
- add `payment` attribute to `takamoa_papi_form` shortcode
- skip payment invitation when `payment="no"` and show a simple thank-you message

## Testing
- `php -l public/class-takamoa-papi-integration-public.php`
- `node -c public/js/takamoa-papi-form.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68a4a2a885f0832ebaa0def1dc655a9c