### PR TITLE
Add basic ticket management to admin interface

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The admin-specific functionality of the plugin.
  *
@@ -47,8 +48,8 @@ class Takamoa_Papi_Integration_Admin
 								'nonce'   => wp_create_nonce('takamoa_papi_nonce'),
 						));
 						wp_enqueue_media();
-				}
 		}
+	}
 
 	/**
 	 * Add admin menu.
@@ -64,24 +65,33 @@ class Takamoa_Papi_Integration_Admin
 			'dashicons-admin-generic',
 			6
 		);
-	
-		add_submenu_page(
-			$this->plugin_name,
-			'Historique des paiements',
-			'Paiements',
-			'manage_options',
-			$this->plugin_name . '-payments',
-			array($this, 'display_payments_page')
-		);
-	
-		add_submenu_page(
-			$this->plugin_name,
-			'Options avancées',
-			'Options',
-			'manage_options',
-			$this->plugin_name . '-settings',
-			array($this, 'display_options_page')
-		);
+
+				add_submenu_page(
+					$this->plugin_name,
+					'Historique des paiements',
+					'Paiements',
+					'manage_options',
+					$this->plugin_name . '-payments',
+					array($this, 'display_payments_page')
+				);
+
+				add_submenu_page(
+					$this->plugin_name,
+					'Billets',
+					'Billets',
+					'manage_options',
+					$this->plugin_name . '-tickets',
+					array($this, 'display_tickets_page')
+				);
+
+				add_submenu_page(
+					$this->plugin_name,
+					'Options avancées',
+					'Options',
+					'manage_options',
+					$this->plugin_name . '-settings',
+					array($this, 'display_options_page')
+				);
 	}
 
 	/**
@@ -90,7 +100,7 @@ class Takamoa_Papi_Integration_Admin
 	public function register_settings()
 	{
 		register_setting('takamoa_papi_key_group', 'takamoa_papi_api_key');
-				
+
 		// URLs
 		register_setting('takamoa_papi_settings_group', 'takamoa_papi_success_url');
 		register_setting('takamoa_papi_settings_group', 'takamoa_papi_failure_url');
@@ -134,7 +144,7 @@ class Takamoa_Papi_Integration_Admin
 			null,
 			$this->plugin_name . '-settings'
 		);
-		
+
 		// Champs de redirection
 		add_settings_field('takamoa_papi_success_url', 'URL après succès', function () {
 			$default = home_url('/paiementreussi');
@@ -184,7 +194,6 @@ class Takamoa_Papi_Integration_Admin
 		add_settings_field('takamoa_papi_test_reason', 'Raison du test', function () {
 			echo '<input type="text" name="takamoa_papi_test_reason" value="' . esc_attr(get_option('takamoa_papi_test_reason')) . '" style="width: 400px;">';
 		}, $this->plugin_name . '-settings', 'takamoa_papi_extra_section');
-		
 	}
 
 	/**
@@ -206,15 +215,16 @@ class Takamoa_Papi_Integration_Admin
 		<?php
 	}
 
-	public function init_admin_route() {
+	public function init_admin_route()
+	{
 		// Optionnel : peut être utilisé plus tard pour des routes personnalisées
 	}
 
 	public function display_payments_page()
 	{
-		global $wpdb;
-		$table = $wpdb->prefix . 'takamoa_papi_payments';
-		$results = $wpdb->get_results("SELECT * FROM $table ORDER BY created_at DESC LIMIT 100");
+			global $wpdb;
+			$table = $wpdb->prefix . 'takamoa_papi_payments';
+			$results = $wpdb->get_results("SELECT * FROM $table ORDER BY created_at DESC LIMIT 100");
 		?>
 		<div class="wrap">
 			<h1>Historique des paiements</h1>
@@ -233,7 +243,7 @@ class Takamoa_Papi_Integration_Admin
 					</tr>
 				</thead>
 				<tbody>
-				<?php foreach ($results as $row): ?>
+			<?php foreach ($results as $row) : ?>
 					<tr class="payment-row"
 						data-reference="<?= esc_attr($row->reference) ?>"
 						data-client="<?= esc_attr($row->client_name) ?>"
@@ -271,7 +281,7 @@ class Takamoa_Papi_Integration_Admin
 						<td><?= esc_html($row->created_at) ?></td>
 						<td><button type="button" class="button takamoa-notify">Notifier</button></td>
 					</tr>
-				<?php endforeach; ?>
+			<?php endforeach; ?>
 				</tbody>
 			</table>
 
@@ -326,24 +336,58 @@ class Takamoa_Papi_Integration_Admin
 				</div>
 			</div>
 		</div>
-		<?php
+			<?php
+	}
+
+	public function display_tickets_page()
+	{
+			global $wpdb;
+			$table = $wpdb->prefix . 'takamoa_papi_tickets';
+			$results = $wpdb->get_results("SELECT * FROM $table ORDER BY created_at DESC LIMIT 100");
+		?>
+				<div class="wrap">
+						<h1>Billets</h1>
+						<table id="takamoa-tickets-table" class="widefat striped">
+								<thead>
+										<tr>
+												<th>Référence</th>
+												<th>Description</th>
+												<th>QR Code</th>
+												<th>Date création</th>
+												<th>Status</th>
+												<th>Dernière notification</th>
+										</tr>
+								</thead>
+								<tbody>
+							<?php foreach ($results as $row) : ?>
+										<tr>
+												<td><?= esc_html($row->reference) ?></td>
+												<td><?= esc_html($row->description ?: '—') ?></td>
+												<td><?= $row->qrcode_link ? '<a href="' . esc_url($row->qrcode_link) . '" target="_blank">Voir</a>' : '—'; ?></td>
+												<td><?= esc_html($row->created_at) ?></td>
+												<td><?= esc_html($row->status) ?></td>
+												<td><?= esc_html($row->last_notification ?: '—') ?></td>
+										</tr>
+							<?php endforeach; ?>
+								</tbody>
+						</table>
+				</div>
+				<?php
 	}
 
 	public function display_options_page()
 	{
 		?>
-		<div class="wrap">
-			<h1>Options avancées</h1>
+				<div class="wrap">
+						<h1>Options avancées</h1>
 			<form method="post" action="options.php">
-				<?php
-				settings_fields('takamoa_papi_settings_group');
-				do_settings_sections($this->plugin_name . '-settings');
-				submit_button();
-				?>
+			<?php
+			settings_fields('takamoa_papi_settings_group');
+			do_settings_sections($this->plugin_name . '-settings');
+			submit_button();
+			?>
 			</form>
 		</div>
 		<?php
 	}
-
-
 }

--- a/admin/css/takamoa-papi-integration-admin.css
+++ b/admin/css/takamoa-papi-integration-admin.css
@@ -1,25 +1,25 @@
 /* General Styles for the Admin Page */
 .wrap {
-    padding: 0;
-    background-color: transparent;
+	padding: 0;
+	background-color: transparent;
 }
 
 /* Title Responsive */
 @media (max-width: 768px) {
-    .wrap h1 {
-        font-size: 1.5rem;
-        text-align: center;
-        width: 100%;
-    }
-    .wrap .add-button-container {
-        text-align: center;
-        width: 100%;
-    }
+	.wrap h1 {
+		font-size: 1.5rem;
+		text-align: center;
+		width: 100%;
+	}
+	.wrap .add-button-container {
+		text-align: center;
+		width: 100%;
+	}
 }
 
 /* Payments table */
 .payment-row {
-    cursor: pointer;
+	cursor: pointer;
 }
 
 /* DataTables custom styling */
@@ -27,67 +27,67 @@
 .datatable-header .dataTables_filter,
 .datatable-footer .dataTables_info,
 .datatable-footer .dt-paging {
-    margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 .dataTables_filter input {
-    width: auto;
+	width: auto;
 }
 
 .dt-paging {
-    display: flex;
-    flex-wrap: wrap;
+	display: flex;
+	flex-wrap: wrap;
 }
 
 .dt-paging .dt-paging-button {
-    margin-right: 0.25rem;
-    padding: 0.25rem 0.5rem;
-    border: 1px solid #dee2e6;
-    background-color: #f8f9fa;
-    color: #212529;
-    border-radius: 0.25rem;
+	margin-right: 0.25rem;
+	padding: 0.25rem 0.5rem;
+	border: 1px solid #dee2e6;
+	background-color: #f8f9fa;
+	color: #212529;
+	border-radius: 0.25rem;
 }
 
 .dt-paging .dt-paging-button.current {
-    background-color: #0073aa;
-    border-color: #0073aa;
-    color: #fff;
+	background-color: #0073aa;
+	border-color: #0073aa;
+	color: #fff;
 }
 .dt-paging .dt-paging-button:not(.disabled):hover {
-    background-color: #e9ecef;
+	background-color: #e9ecef;
 }
 
 .dt-paging .dt-paging-button.disabled {
-    opacity: 0.65;
-    cursor: default;
+	opacity: 0.65;
+	cursor: default;
 }
 
 /* Payment modal styling */
 #paymentModal .modal-header {
-    background-color: #0073aa;
-    color: #fff;
+	background-color: #0073aa;
+	color: #fff;
 }
 
 #paymentModal .modal-header .btn-close {
-    filter: invert(1);
+	filter: invert(1);
 }
 
 #paymentModal .table th {
-    width: 40%;
-    white-space: nowrap;
+	width: 40%;
+	white-space: nowrap;
 }
 
 #paymentModal .table-responsive {
-    max-height: 70vh;
-    overflow-y: auto;
+	max-height: 70vh;
+	overflow-y: auto;
 }
 
 #paymentModal .table td {
-    word-break: break-word;
+	word-break: break-word;
 }
 
 #paymentModal pre {
-    white-space: pre-wrap;
-    word-break: break-word;
-    font-size: 0.875rem;
+	white-space: pre-wrap;
+	word-break: break-word;
+	font-size: 0.875rem;
 }

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -1,77 +1,98 @@
 jQuery(document).ready(function($) {
-    var table = $('#takamoa-payments-table').DataTable({
-        pageLength: 10,
-        lengthMenu: [5, 10, 25, 50],
-        pagingType: 'full_numbers',
-        dom: '<"datatable-header d-flex justify-content-between align-items-center mb-3"lf>rt<"datatable-footer d-flex justify-content-between align-items-center mt-3"ip>',
-        language: {
-            lengthMenu: '_MENU_',
-            search: '',
-            searchPlaceholder: 'Search…'
-        }
-    });
+	if ($('#takamoa-payments-table').length) {
+		var table = $('#takamoa-payments-table').DataTable({
+			pageLength: 10,
+			lengthMenu: [5, 10, 25, 50],
+			pagingType: 'full_numbers',
+			dom: '<"datatable-header d-flex justify-content-between align-items-center mb-3"lf>rt<"datatable-footer d-flex justify-content-between align-items-center mt-3"ip>',
+			language: {
+				lengthMenu: '_MENU_',
+				search: '',
+				searchPlaceholder: 'Search…'
+			}
+		});
 
-    var wrapper = $('#takamoa-payments-table_wrapper');
-    wrapper.find('.dataTables_length select').addClass('form-select form-select-sm');
-    wrapper.find('.dataTables_filter input').addClass('form-control form-control-sm').attr('placeholder', 'Search…');
-    wrapper.find('.dataTables_length label, .dataTables_filter label').addClass('d-flex align-items-center gap-2 mb-0');
+		var wrapper = $('#takamoa-payments-table_wrapper');
+		wrapper.find('.dataTables_length select').addClass('form-select form-select-sm');
+		wrapper.find('.dataTables_filter input').addClass('form-control form-control-sm').attr('placeholder', 'Search…');
+		wrapper.find('.dataTables_length label, .dataTables_filter label').addClass('d-flex align-items-center gap-2 mb-0');
 
-    $('#takamoa-payments-table tbody').on('click', 'tr.payment-row', function() {
-        var row = $(this);
-        $('#modal-reference').text(row.data('reference'));
-        $('#modal-name').text(row.data('client'));
-        $('#modal-email').text(row.data('email') || '—');
-        $('#modal-phone').text(row.data('phone') || '—');
-        $('#modal-amount').text(row.data('amount'));
-        $('#modal-status').text(row.data('status'));
-        $('#modal-method').text(row.data('method'));
-        $('#modal-date').text(row.data('date'));
-        $('#modal-description').text(row.data('description') || '—');
-        $('#modal-id').text(row.data('id'));
-        $('#modal-provider').text(row.data('provider') || '—');
-        $('#modal-success-url').text(row.data('successUrl') || '—');
-        $('#modal-failure-url').text(row.data('failureUrl') || '—');
-        $('#modal-notification-url').text(row.data('notificationUrl') || '—');
-        $('#modal-link-creation').text(row.data('linkCreation') || '—');
-        $('#modal-link-expiration').text(row.data('linkExpiration') || '—');
-        $('#modal-payment-link').text(row.data('paymentLink') || '—');
-        $('#modal-currency').text(row.data('currency') || '—');
-        $('#modal-fee').text(row.data('fee') || '—');
-        $('#modal-notification-token').text(row.data('notificationToken') || '—');
-        $('#modal-test-mode').text(row.data('isTestMode') ? 'Yes' : 'No');
-        $('#modal-test-reason').text(row.data('testReason') || '—');
-        $('#modal-raw-request').text(row.data('rawRequest') || '—');
-        $('#modal-raw-response').text(row.data('rawResponse') || '—');
-        $('#modal-raw-notification').text(row.data('rawNotification') || '—');
-        $('#modal-updated-at').text(row.data('updatedAt') || '—');
+		$('#takamoa-payments-table tbody').on('click', 'tr.payment-row', function() {
+			var row = $(this);
+			$('#modal-reference').text(row.data('reference'));
+			$('#modal-name').text(row.data('client'));
+			$('#modal-email').text(row.data('email') || '—');
+			$('#modal-phone').text(row.data('phone') || '—');
+			$('#modal-amount').text(row.data('amount'));
+			$('#modal-status').text(row.data('status'));
+			$('#modal-method').text(row.data('method'));
+			$('#modal-date').text(row.data('date'));
+			$('#modal-description').text(row.data('description') || '—');
+			$('#modal-id').text(row.data('id'));
+			$('#modal-provider').text(row.data('provider') || '—');
+			$('#modal-success-url').text(row.data('successUrl') || '—');
+			$('#modal-failure-url').text(row.data('failureUrl') || '—');
+			$('#modal-notification-url').text(row.data('notificationUrl') || '—');
+			$('#modal-link-creation').text(row.data('linkCreation') || '—');
+			$('#modal-link-expiration').text(row.data('linkExpiration') || '—');
+			$('#modal-payment-link').text(row.data('paymentLink') || '—');
+			$('#modal-currency').text(row.data('currency') || '—');
+			$('#modal-fee').text(row.data('fee') || '—');
+			$('#modal-notification-token').text(row.data('notificationToken') || '—');
+			$('#modal-test-mode').text(row.data('isTestMode') ? 'Yes' : 'No');
+			$('#modal-test-reason').text(row.data('testReason') || '—');
+			$('#modal-raw-request').text(row.data('rawRequest') || '—');
+			$('#modal-raw-response').text(row.data('rawResponse') || '—');
+			$('#modal-raw-notification').text(row.data('rawNotification') || '—');
+			$('#modal-updated-at').text(row.data('updatedAt') || '—');
 
-        $('#modal-extra-info').addClass('d-none');
-        $('#toggle-more-info').text('Show more');
+			$('#modal-extra-info').addClass('d-none');
+			$('#toggle-more-info').text('Show more');
 
-        var modal = new bootstrap.Modal(document.getElementById('paymentModal'));
-        modal.show();
-    });
+			var modal = new bootstrap.Modal(document.getElementById('paymentModal'));
+			modal.show();
+		});
 
-    $('#toggle-more-info').on('click', function() {
-        $('#modal-extra-info').toggleClass('d-none');
-        $(this).text($('#modal-extra-info').hasClass('d-none') ? 'Show more' : 'Show less');
-    });
+		$('#toggle-more-info').on('click', function() {
+			$('#modal-extra-info').toggleClass('d-none');
+			$(this).text($('#modal-extra-info').hasClass('d-none') ? 'Show more' : 'Show less');
+		});
 
-    $(document).on('click', '.takamoa-notify', function(e) {
-        e.stopPropagation();
-        var btn = $(this);
-        var row = btn.closest('tr');
-        btn.prop('disabled', true);
-        $.post(takamoaAjax.ajaxurl, {
-            action: 'takamoa_resend_payment_email',
-            nonce: takamoaAjax.nonce,
-            reference: row.data('reference')
-        }).done(function(res) {
-            alert(res.data && res.data.message ? res.data.message : 'Notification envoyée');
-        }).fail(function() {
-            alert('Erreur lors de l\'envoi de la notification');
-        }).always(function(){
-            btn.prop('disabled', false);
-        });
-    });
+		$(document).on('click', '.takamoa-notify', function(e) {
+			e.stopPropagation();
+			var btn = $(this);
+			var row = btn.closest('tr');
+			btn.prop('disabled', true);
+			$.post(takamoaAjax.ajaxurl, {
+				action: 'takamoa_resend_payment_email',
+				nonce: takamoaAjax.nonce,
+				reference: row.data('reference')
+			}).done(function(res) {
+				alert(res.data && res.data.message ? res.data.message : 'Notification envoyée');
+			}).fail(function() {
+				alert('Erreur lors de l\'envoi de la notification');
+			}).always(function(){
+				btn.prop('disabled', false);
+			});
+		});
+	}
+
+	if ($('#takamoa-tickets-table').length) {
+		var ttable = $('#takamoa-tickets-table').DataTable({
+			pageLength: 10,
+			lengthMenu: [5, 10, 25, 50],
+			pagingType: 'full_numbers',
+			dom: '<"datatable-header d-flex justify-content-between align-items-center mb-3"lf>rt<"datatable-footer d-flex justify-content-between align-items-center mt-3"ip>',
+			language: {
+				lengthMenu: '_MENU_',
+				search: '',
+				searchPlaceholder: 'Search…'
+			}
+		});
+
+		var twrapper = $('#takamoa-tickets-table_wrapper');
+		twrapper.find('.dataTables_length select').addClass('form-select form-select-sm');
+		twrapper.find('.dataTables_filter input').addClass('form-control form-control-sm').attr('placeholder', 'Search…');
+		twrapper.find('.dataTables_length label, .dataTables_filter label').addClass('d-flex align-items-center gap-2 mb-0');
+	}
 });

--- a/includes/class-takamoa-papi-integration-activator.php
+++ b/includes/class-takamoa-papi-integration-activator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Fired during plugin activation
  *
@@ -19,26 +20,27 @@
  * @subpackage takamoa-papi-integration/includes
  * @author     Nexa by Takamoa <nexa.takamoa@gmail.com>
  */
-class Takamoa_Papi_Integration_Activator {
-
+class Takamoa_Papi_Integration_Activator
+{
 	/**
 	 * Short Description. (use period)
 	 *
 	 * Long Description.
 	 *
 	 * @since    0.0.1
-	 */    
-    public static function activate() {
+	 */
+	public static function activate()
+	{
 		global $wpdb;
-		$table = $wpdb->prefix . 'takamoa_papi_payments';
+				$table = $wpdb->prefix . 'takamoa_papi_payments';
 
-		$charset_collate = $wpdb->get_charset_collate();
+				$charset_collate = $wpdb->get_charset_collate();
 
-		$sql = "CREATE TABLE $table (
-			id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-			reference VARCHAR(100) NOT NULL,
-			client_name VARCHAR(255) NOT NULL,
-			amount DECIMAL(10,2) NOT NULL,
+				$sql = "CREATE TABLE $table (
+						id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+						reference VARCHAR(100) NOT NULL,
+						client_name VARCHAR(255) NOT NULL,
+						amount DECIMAL(10,2) NOT NULL,
 			description VARCHAR(255),
 			payer_email VARCHAR(255),
 			payer_phone VARCHAR(50),
@@ -61,11 +63,27 @@ class Takamoa_Papi_Integration_Activator {
 			raw_notification LONGTEXT,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-			UNIQUE KEY unique_reference (reference)
-		) $charset_collate;";
+						UNIQUE KEY unique_reference (reference)
+				) $charset_collate;";
 
-		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-		dbDelta($sql);
+				require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+				dbDelta($sql);
+
+				// Tickets table
+				$tickets_table = $wpdb->prefix . 'takamoa_papi_tickets';
+
+				$sql_tickets = "CREATE TABLE $tickets_table (
+						id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+						reference VARCHAR(100) NOT NULL,
+						qrcode_link TEXT,
+						description TEXT,
+						created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+						status VARCHAR(50) DEFAULT 'PENDING',
+						last_notification DATETIME NULL,
+						UNIQUE KEY unique_reference (reference)
+				) $charset_collate;";
+
+				dbDelta($sql_tickets);
 
 		// Options par défaut à créer
 		add_option('takamoa_papi_api_key', '');
@@ -84,4 +102,3 @@ class Takamoa_Papi_Integration_Activator {
 		add_option('takamoa_papi_test_reason', '');
 	}
 }
-?>

--- a/includes/class-takamoa-papi-integration-functions.php
+++ b/includes/class-takamoa-papi-integration-functions.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Fired during plugin activation
  *
@@ -19,66 +20,71 @@
  * @subpackage takamoa-papi-integration/includes
  * @author     Nexa by Takamoa <nexa.takamoa@gmail.com>
  */
-class Takamoa_Papi_Integration_Functions {
-
-		private function send_registration_email($email, $name, $link) {
-				if (empty($email)) {
-						return;
-				}
-
-				$subject = "Confirmation d'inscription et modalités de paiement";
-
-				$message  = '<p>Bonjour ' . esc_html($name) . ',</p>';
-				$message .= '<p>Nous vous confirmons que votre inscription a bien été enregistrée.</p>';
-				$message .= '<p>Pour réserver définitivement votre place et finaliser votre paiement, veuillez cliquer sur le bouton ci-dessous :</p>';
-				$message .= '<p><a href="' . esc_url($link) . '" style="display:inline-block;padding:10px 20px;background:#0073aa;color:#fff;text-decoration:none;">Réserver et payer</a></p>';
-				$message .= '<p>Pour toute question ou précision, notre équipe logistique se tient à votre disposition au 034 04 105 06.</p>';
-				$message .= '<p>Bien cordialement,<br>L’équipe logistique</p>';
-				$logo = get_site_icon_url();
-				if ($logo) {
-						$logo = set_url_scheme($logo, 'https');
-						$message .= '<p><img src="' . esc_url($logo) . '" alt="Logo" style="max-width:150px;height:auto;"></p>';
-				}
-
-				$headers = ['Content-Type: text/html; charset=UTF-8'];
-				wp_mail($email, $subject, $message, $headers);
+class Takamoa_Papi_Integration_Functions
+{
+	private function send_registration_email($email, $name, $link)
+	{
+		if (empty($email)) {
+				return;
 		}
 
-		private function send_payment_success_email($email, $name) {
-				if (empty($email)) {
-						return;
-				}
+			$subject = "Confirmation d'inscription et modalités de paiement";
 
-				$subject = 'Confirmation de paiement';
-
-				$message  = '<p>Bonjour ' . esc_html($name) . ',</p>';
-				$message .= '<p>Nous vous confirmons que votre paiement a bien été reçu. Merci pour votre inscription.</p>';
-				$message .= '<p>Pour toute question ou précision, notre équipe logistique se tient à votre disposition au 034 04 105 06.</p>';
-				$message .= '<p>Bien cordialement,<br>L’équipe logistique</p>';
-				$logo = get_site_icon_url();
-				if ($logo) {
-						$logo = set_url_scheme($logo, 'https');
-						$message .= '<p><img src="' . esc_url($logo) . '" alt="Logo" style="max-width:150px;height:auto;"></p>';
-				}
-
-				$headers = ['Content-Type: text/html; charset=UTF-8'];
-				wp_mail($email, $subject, $message, $headers);
+			$message  = '<p>Bonjour ' . esc_html($name) . ',</p>';
+			$message .= '<p>Nous vous confirmons que votre inscription a bien été enregistrée.</p>';
+			$message .= '<p>Pour réserver définitivement votre place et finaliser votre paiement, veuillez cliquer sur le bouton ci-dessous :</p>';
+			$message .= '<p><a href="' . esc_url($link) . '" style="display:inline-block;padding:10px 20px;background:#0073aa;color:#fff;text-decoration:none;">Réserver et payer</a></p>';
+			$message .= '<p>Pour toute question ou précision, notre équipe logistique se tient à votre disposition au 034 04 105 06.</p>';
+			$message .= '<p>Bien cordialement,<br>L’équipe logistique</p>';
+			$logo = get_site_icon_url();
+		if ($logo) {
+				$logo = set_url_scheme($logo, 'https');
+				$message .= '<p><img src="' . esc_url($logo) . '" alt="Logo" style="max-width:150px;height:auto;"></p>';
 		}
 
-	public function register_endpoints() {
+			$headers = ['Content-Type: text/html; charset=UTF-8'];
+			wp_mail($email, $subject, $message, $headers);
+	}
+
+	private function send_payment_success_email($email, $name)
+	{
+		if (empty($email)) {
+				return;
+		}
+
+			$subject = 'Confirmation de paiement';
+
+			$message  = '<p>Bonjour ' . esc_html($name) . ',</p>';
+			$message .= '<p>Nous vous confirmons que votre paiement a bien été reçu. Merci pour votre inscription.</p>';
+			$message .= '<p>Pour toute question ou précision, notre équipe logistique se tient à votre disposition au 034 04 105 06.</p>';
+			$message .= '<p>Bien cordialement,<br>L’équipe logistique</p>';
+			$logo = get_site_icon_url();
+		if ($logo) {
+				$logo = set_url_scheme($logo, 'https');
+				$message .= '<p><img src="' . esc_url($logo) . '" alt="Logo" style="max-width:150px;height:auto;"></p>';
+		}
+
+			$headers = ['Content-Type: text/html; charset=UTF-8'];
+			wp_mail($email, $subject, $message, $headers);
+	}
+
+	public function register_endpoints()
+	{
 		add_rewrite_endpoint('paiementreussi', EP_ROOT);
 		add_rewrite_endpoint('paiementechoue', EP_ROOT);
 		add_rewrite_endpoint('papi-notify', EP_ROOT);
 	}
 
-	public function register_query_vars($vars) {
+	public function register_query_vars($vars)
+	{
 		$vars[] = 'paiementreussi';
 		$vars[] = 'paiementechoue';
 		$vars[] = 'papi-notify';
 		return $vars;
 	}
 
-	public function handle_endpoints() {
+	public function handle_endpoints()
+	{
 		global $wp_query;
 
 		if (isset($wp_query->query_vars['paiementreussi'])) {
@@ -95,7 +101,8 @@ class Takamoa_Papi_Integration_Functions {
 		}
 	}
 
-	public function handle_notification() {
+	public function handle_notification()
+	{
 		$body = json_decode(file_get_contents('php://input'), true);
 
 		if (!$body || !isset($body['paymentReference'], $body['notificationToken'])) {
@@ -112,7 +119,8 @@ class Takamoa_Papi_Integration_Functions {
 
 		$payment = $wpdb->get_row($wpdb->prepare(
 			"SELECT * FROM $table WHERE reference = %s AND notification_token = %s LIMIT 1",
-			$reference, $token
+			$reference,
+			$token
 		));
 
 		if (!$payment) {
@@ -132,17 +140,31 @@ class Takamoa_Papi_Integration_Functions {
 						'updated_at'       => current_time('mysql')
 				], ['id' => $payment->id]);
 
-				if ($status === 'SUCCESS') {
+		if ($status === 'SUCCESS') {
 						$this->send_payment_success_email($payment->payer_email, $payment->client_name);
-				}
+
+						// Generate ticket if not already created
+						$tickets_table = $wpdb->prefix . 'takamoa_papi_tickets';
+						$exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM $tickets_table WHERE reference = %s", $payment->reference));
+
+			if (!$exists) {
+										$wpdb->insert($tickets_table, [
+														'reference'   => $payment->reference,
+														'description' => $payment->description,
+														'status'      => 'PENDING',
+														'created_at'  => current_time('mysql')
+										]);
+			}
+		}
 
 				status_header(200);
 				echo json_encode(['success' => true]);
-		}
+	}
 
-	public function handle_create_payment_ajax() {
+	public function handle_create_payment_ajax()
+	{
 		check_ajax_referer('takamoa_papi_nonce');
-	
+
 		// Vérifie les données
 		$clientName  = sanitize_text_field($_POST['clientName'] ?? '');
 		$amount      = floatval($_POST['amount'] ?? 0);
@@ -242,28 +264,30 @@ class Takamoa_Papi_Integration_Functions {
 		wp_send_json_success(['link' => $link]);
 	}
 
-	public function handle_check_payment_status_ajax() {
+	public function handle_check_payment_status_ajax()
+	{
 		check_ajax_referer('takamoa_papi_nonce');
-	
+
 		$reference = sanitize_text_field($_POST['reference'] ?? '');
-	
+
 		if (!$reference) {
 			wp_send_json_error(['message' => 'Référence manquante.']);
 		}
-	
+
 		global $wpdb;
 		$table = $wpdb->prefix . 'takamoa_papi_payments';
-	
+
 		$status = $wpdb->get_var($wpdb->prepare("SELECT payment_status FROM $table WHERE reference = %s LIMIT 1", $reference));
-	
+
 		if (!$status) {
 			wp_send_json_error(['message' => 'Paiement introuvable.']);
 		}
-	
+
 		wp_send_json_success(['status' => $status]);
 	}
 
-	public function handle_resend_payment_email_ajax() {
+	public function handle_resend_payment_email_ajax()
+	{
 		check_ajax_referer('takamoa_papi_nonce', 'nonce');
 
 		if (!current_user_can('manage_options')) {
@@ -287,5 +311,4 @@ class Takamoa_Papi_Integration_Functions {
 
 		wp_send_json_success(['message' => 'Notification envoyée.']);
 	}
-	
 }

--- a/includes/class-takamoa-papi-integration-loader.php
+++ b/includes/class-takamoa-papi-integration-loader.php
@@ -107,7 +107,7 @@ class Takamoa_Papi_Integration_Loader{
 
 	}
 
-    	/**
+		/**
 	 * Register the filters and actions with WordPress.
 	 *
 	 * @since    0.0.1

--- a/public/class-takamoa-papi-integration-public.php
+++ b/public/class-takamoa-papi-integration-public.php
@@ -101,15 +101,15 @@ class Takamoa_Papi_Integration_Public {
 	/**
 	 * Shortcode qui affiche le conteneur Vue.js
 	 */
-        public function render_vue_form_shortcode($atts) {
-                $atts = shortcode_atts([
-                        'amount' => '',
-                        'reference' => '',
-                        'payment' => 'yes'
-                ], $atts);
+		public function render_vue_form_shortcode($atts) {
+				$atts = shortcode_atts([
+						'amount' => '',
+						'reference' => '',
+						'payment' => 'yes'
+				], $atts);
 
-                // Assure que le paramètre payment n'accepte que 'yes' ou 'no'
-                $atts['payment'] = in_array($atts['payment'], ['yes', 'no'], true) ? $atts['payment'] : 'yes';
+				// Assure que le paramètre payment n'accepte que 'yes' ou 'no'
+				$atts['payment'] = in_array($atts['payment'], ['yes', 'no'], true) ? $atts['payment'] : 'yes';
 	
 		$timestamp = time();
 	
@@ -128,12 +128,12 @@ class Takamoa_Papi_Integration_Public {
 	
 		ob_start();
 		?>
-                <div id="<?php echo esc_attr($uid); ?>"
-                         class="takamoa-papi-app"
-                         data-amount="<?php echo esc_attr($atts['amount']); ?>"
-                         data-reference="<?php echo esc_attr($atts['reference']); ?>"
-                         data-payment="<?php echo esc_attr($atts['payment']); ?>">
-                </div>
+				<div id="<?php echo esc_attr($uid); ?>"
+						 class="takamoa-papi-app"
+						 data-amount="<?php echo esc_attr($atts['amount']); ?>"
+						 data-reference="<?php echo esc_attr($atts['reference']); ?>"
+						 data-payment="<?php echo esc_attr($atts['payment']); ?>">
+				</div>
 		<?php
 		return ob_get_clean();
 	}

--- a/public/css/takamoa-papi-integration-public.css
+++ b/public/css/takamoa-papi-integration-public.css
@@ -1,6 +1,6 @@
 .takamoa-papi-form {
 	text-align: center;
-    position: relative;
+	position: relative;
 }
 
 .takamoa-papi-form-box {

--- a/public/js/takamoa-papi-form.js
+++ b/public/js/takamoa-papi-form.js
@@ -1,29 +1,29 @@
 const appRoot = document.getElementById('takamoa-papi-app');
 
 document.querySelectorAll('.takamoa-papi-app').forEach((el, index) => {
-        new Vue({
-                el,
-                data: {
-            clientFirstName: '',
-                clientLastName: '',
-                        amount: el.dataset.amount || '',
-                        reference: el.dataset.reference || '',
-                        payment: el.dataset.payment === 'no' ? 'no' : 'yes',
-                        payerEmail: '',
-                        payerPhone: '',
-                        description: '',
-                        provider: '',
-                        loading: false,
-                        link: '',
-                        status: '',
-                        error: '',
-                        success: '',
-                        polling: null
-                },
+		new Vue({
+				el,
+				data: {
+			clientFirstName: '',
+				clientLastName: '',
+						amount: el.dataset.amount || '',
+						reference: el.dataset.reference || '',
+						payment: el.dataset.payment === 'no' ? 'no' : 'yes',
+						payerEmail: '',
+						payerPhone: '',
+						description: '',
+						provider: '',
+						loading: false,
+						link: '',
+						status: '',
+						error: '',
+						success: '',
+						polling: null
+				},
 		computed: {
-            clientName() {
-                return `${this.clientFirstName} ${this.clientLastName}`.trim();
-            },
+			clientName() {
+				return `${this.clientFirstName} ${this.clientLastName}`.trim();
+			},
 			fields() {
 				return TakamoaPapiVars.optionalFields || [];
 			},
@@ -37,171 +37,171 @@ document.querySelectorAll('.takamoa-papi-app').forEach((el, index) => {
 			}
 		},
 		methods: {
-                        submitForm() {
-                                this.loading = true;
-                                this.error = '';
-                                this.link = '';
-                                this.success = '';
-                                this.status = '';
+						submitForm() {
+								this.loading = true;
+								this.error = '';
+								this.link = '';
+								this.success = '';
+								this.status = '';
 
-                                if (this.payment === 'no') {
-                                        this.success = 'Merci pour votre inscription.';
-                                        this.loading = false;
-                                        return;
-                                }
+								if (this.payment === 'no') {
+										this.success = 'Merci pour votre inscription.';
+										this.loading = false;
+										return;
+								}
 
-                                const data = {
-                                        action: 'takamoa_create_payment',
-                                        _ajax_nonce: TakamoaPapiVars.api_nonce,
-                                        clientName: this.clientName,
-                                        amount: this.amount,
-                                        reference: this.reference,
-                                        payerEmail: this.payerEmail,
-                                        payerPhone: this.payerPhone,
-                                        description: this.description
-                                };
+								const data = {
+										action: 'takamoa_create_payment',
+										_ajax_nonce: TakamoaPapiVars.api_nonce,
+										clientName: this.clientName,
+										amount: this.amount,
+										reference: this.reference,
+										payerEmail: this.payerEmail,
+										payerPhone: this.payerPhone,
+										description: this.description
+								};
 
-                if (this.provider) {
-                                        data.provider = this.provider;
-                                }
+				if (this.provider) {
+										data.provider = this.provider;
+								}
 
-                                fetch(TakamoaPapiVars.ajax_url, {
-                                        method: 'POST',
-                                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                                        body: new URLSearchParams(data)
-                                })
-                                .then(res => res.json())
-                                .then(res => {
-                                        if (res.success && res.data.link) {
-                                                this.link = res.data.link;
-                                                window.open(this.link, '_blank');
-                        this.polling = setInterval(this.checkStatus, 2000);
-                                        } else {
-                                                this.error = res.data?.message || 'Erreur';
-                                                this.loading = false;
-                                        }
-                                })
-                                .catch(() => {
-                                        this.loading = false;
-                                        this.error = 'Erreur réseau. Veuillez réessayer.';
-                                });
-                        },
+								fetch(TakamoaPapiVars.ajax_url, {
+										method: 'POST',
+										headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+										body: new URLSearchParams(data)
+								})
+								.then(res => res.json())
+								.then(res => {
+										if (res.success && res.data.link) {
+												this.link = res.data.link;
+												window.open(this.link, '_blank');
+						this.polling = setInterval(this.checkStatus, 2000);
+										} else {
+												this.error = res.data?.message || 'Erreur';
+												this.loading = false;
+										}
+								})
+								.catch(() => {
+										this.loading = false;
+										this.error = 'Erreur réseau. Veuillez réessayer.';
+								});
+						},
 			checkStatus() {
-                if (!this.reference) return;
-            
-                const data = {
-                    action: 'takamoa_check_payment_status',
-                    _ajax_nonce: TakamoaPapiVars.api_nonce,
-                    reference: this.reference
-                };
-            
-                fetch(TakamoaPapiVars.ajax_url, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                    body: new URLSearchParams(data)
-                })
-                .then(res => res.json())
-                .then(res => {
-                    if (res.success && res.data.status) {
-                        const status = res.data.status;
-            
-                        if (status === 'SUCCESS') {
-                            clearInterval(this.polling);
-                            this.status = 'SUCCESS';
-                            this.success = 'Paiement confirmé. Merci pour votre inscription.';
-                            this.loading = false;
-                        }
-                        else if (status === 'FAILED') {
-                            clearInterval(this.polling);
-                            this.status = 'FAILED';
-                            this.error = 'Le paiement a échoué. Veuillez réessayer ou contacter le support.';
-                            this.loading = false;
-                        }
-                    }
-                })
-                .catch(() => {
-                    clearInterval(this.polling);
-                    this.error = 'Erreur lors de la vérification du paiement.';
-                    this.loading = false;
-                });
-            }
+				if (!this.reference) return;
+			
+				const data = {
+					action: 'takamoa_check_payment_status',
+					_ajax_nonce: TakamoaPapiVars.api_nonce,
+					reference: this.reference
+				};
+			
+				fetch(TakamoaPapiVars.ajax_url, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+					body: new URLSearchParams(data)
+				})
+				.then(res => res.json())
+				.then(res => {
+					if (res.success && res.data.status) {
+						const status = res.data.status;
+			
+						if (status === 'SUCCESS') {
+							clearInterval(this.polling);
+							this.status = 'SUCCESS';
+							this.success = 'Paiement confirmé. Merci pour votre inscription.';
+							this.loading = false;
+						}
+						else if (status === 'FAILED') {
+							clearInterval(this.polling);
+							this.status = 'FAILED';
+							this.error = 'Le paiement a échoué. Veuillez réessayer ou contacter le support.';
+							this.loading = false;
+						}
+					}
+				})
+				.catch(() => {
+					clearInterval(this.polling);
+					this.error = 'Erreur lors de la vérification du paiement.';
+					this.loading = false;
+				});
+			}
 		},
-                template: `
-            <div class="takamoa-papi-form" :class="{ 'is-loading': loading }">
-                                <div class="takamoa-papi-loading-overlay" v-if="loading && payment === 'yes'">
-                    <div class="spinner"></div>
-                    <p v-if="link" class="takamoa-papi-message">
-                        Félicitations ! Vous êtes inscrit.<br>
-                        Pour confirmer votre place, veuillez procéder au paiement :
-                        <br>
-                        <a :href="link" target="_blank" class="takamoa-papi-link">Confirmer mon inscription par paiement</a>
-                    </p>
-                </div>
+				template: `
+			<div class="takamoa-papi-form" :class="{ 'is-loading': loading }">
+								<div class="takamoa-papi-loading-overlay" v-if="loading && payment === 'yes'">
+					<div class="spinner"></div>
+					<p v-if="link" class="takamoa-papi-message">
+						Félicitations ! Vous êtes inscrit.<br>
+						Pour confirmer votre place, veuillez procéder au paiement :
+						<br>
+						<a :href="link" target="_blank" class="takamoa-papi-link">Confirmer mon inscription par paiement</a>
+					</p>
+				</div>
 
 
-                <form @submit.prevent="submitForm" class="takamoa-papi-form-box">
-                    <input
-                        id="clientLastName"
-                        name="clientLastName"
-                        v-model="clientLastName"
-                        required
-                        placeholder="NOM"
-                        class="takamoa-papi-input"
-                    />
-                    <input
-                        id="clientFirstName"
-                        name="clientFirstName"
-                        v-model="clientFirstName"
-                        required
-                        placeholder="PRÉNOM"
-                        class="takamoa-papi-input"
-                    />
-                    <input
-                        id="payerPhone"
-                        name="payerPhone"
-                        v-model="payerPhone"
-                        required
-                        placeholder="TÉLÉPHONE"
-                        class="takamoa-papi-input"
-                    />
-                    <input
-                        id="payerEmail"
-                        name="payerEmail"
-                        v-model="payerEmail"
-                        required
-                        placeholder="EMAIL"
-                        class="takamoa-papi-input"
-                    />
-                    <input
-                        id="description"
-                        name="description"
-                        v-model="description"
-                        required
-                        placeholder="ENTREPRISE"
-                        class="takamoa-papi-input"
-                    />
+				<form @submit.prevent="submitForm" class="takamoa-papi-form-box">
+					<input
+						id="clientLastName"
+						name="clientLastName"
+						v-model="clientLastName"
+						required
+						placeholder="NOM"
+						class="takamoa-papi-input"
+					/>
+					<input
+						id="clientFirstName"
+						name="clientFirstName"
+						v-model="clientFirstName"
+						required
+						placeholder="PRÉNOM"
+						class="takamoa-papi-input"
+					/>
+					<input
+						id="payerPhone"
+						name="payerPhone"
+						v-model="payerPhone"
+						required
+						placeholder="TÉLÉPHONE"
+						class="takamoa-papi-input"
+					/>
+					<input
+						id="payerEmail"
+						name="payerEmail"
+						v-model="payerEmail"
+						required
+						placeholder="EMAIL"
+						class="takamoa-papi-input"
+					/>
+					<input
+						id="description"
+						name="description"
+						v-model="description"
+						required
+						placeholder="ENTREPRISE"
+						class="takamoa-papi-input"
+					/>
 
 
-                    <div v-if="providers.length > 1">
-                        <select
-                            id="provider"
-                            name="provider"
-                            v-model="provider"
-                            class="takamoa-papi-input"
-                        >
-                            <option disabled value="">Choisir une méthode de paiement</option>
-                            <option v-for="p in providers" :value="p">{{ p }}</option>
-                        </select>
-                    </div>
+					<div v-if="providers.length > 1">
+						<select
+							id="provider"
+							name="provider"
+							v-model="provider"
+							class="takamoa-papi-input"
+						>
+							<option disabled value="">Choisir une méthode de paiement</option>
+							<option v-for="p in providers" :value="p">{{ p }}</option>
+						</select>
+					</div>
 
-                    <button type="submit" :disabled="loading" class="takamoa-papi-button">
-                        {{ loading ? 'Veuillez patienter...' : 'S’INSCRIRE' }}
-                    </button>
+					<button type="submit" :disabled="loading" class="takamoa-papi-button">
+						{{ loading ? 'Veuillez patienter...' : 'S’INSCRIRE' }}
+					</button>
 
-                    <p v-if="success" class="takamoa-papi-success">{{ success }}</p>
-                    <p v-if="error" class="takamoa-papi-error">{{ error }}</p>
-                </form>
-            </div>
-        `
+					<p v-if="success" class="takamoa-papi-success">{{ success }}</p>
+					<p v-if="error" class="takamoa-papi-error">{{ error }}</p>
+				</form>
+			</div>
+		`
 	});
 });

--- a/uninstall.php
+++ b/uninstall.php
@@ -28,12 +28,12 @@
 // If uninstall not called from WordPress, then exit.
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	delete_option('takamoa_papi_api_key');
-    delete_option('takamoa_papi_success_url');
-    delete_option('takamoa_papi_failure_url');
-    delete_option('takamoa_papi_notification_url');
-    delete_option('takamoa_papi_valid_duration');
-    delete_option('takamoa_papi_providers');
-    delete_option('takamoa_papi_optional_fields');
-    delete_option('takamoa_papi_test_mode');
-    delete_option('takamoa_papi_test_reason');
+	delete_option('takamoa_papi_success_url');
+	delete_option('takamoa_papi_failure_url');
+	delete_option('takamoa_papi_notification_url');
+	delete_option('takamoa_papi_valid_duration');
+	delete_option('takamoa_papi_providers');
+	delete_option('takamoa_papi_optional_fields');
+	delete_option('takamoa_papi_test_mode');
+	delete_option('takamoa_papi_test_reason');
 }


### PR DESCRIPTION
## Summary
- create database table for tickets during plugin activation
- generate tickets after successful payment notifications
- add Billets admin submenu with ticket list
- initialize DataTables for ticket listing
- replace space-based indentation with tabs across PHP, JS, and CSS

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l includes/class-takamoa-papi-integration-activator.php`
- `php -l includes/class-takamoa-papi-integration-functions.php`
- `php -l includes/class-takamoa-papi-integration-loader.php`
- `php -l public/class-takamoa-papi-integration-public.php`
- `php -l uninstall.php`
- `node --check admin/js/takamoa-papi-integration-admin.js`
- `node --check public/js/takamoa-papi-form.js`
- `npx --yes stylelint admin/css/takamoa-papi-integration-admin.css public/css/takamoa-papi-integration-public.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a6002568832e94208e5257ce8bdc