### PR TITLE
Add ticket design management

### DIFF
--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -92,7 +92,30 @@ jQuery(document).ready(function($) {
 
 		var twrapper = $('#takamoa-tickets-table_wrapper');
 		twrapper.find('.dataTables_length select').addClass('form-select form-select-sm');
-		twrapper.find('.dataTables_filter input').addClass('form-control form-control-sm').attr('placeholder', 'Search…');
-		twrapper.find('.dataTables_length label, .dataTables_filter label').addClass('d-flex align-items-center gap-2 mb-0');
-	}
+twrapper.find('.dataTables_filter input').addClass('form-control form-control-sm').attr('placeholder', 'Search…');
+twrapper.find('.dataTables_length label, .dataTables_filter label').addClass('d-flex align-items-center gap-2 mb-0');
+}
+
+if ($('#select_design_image').length) {
+var frame;
+$('#select_design_image').on('click', function(e) {
+e.preventDefault();
+if (frame) {
+frame.open();
+return;
+}
+frame = wp.media({
+title: 'Choisir une image',
+button: { text: 'Utiliser cette image' },
+multiple: false
+});
+frame.on('select', function() {
+var att = frame.state().get('selection').first().toJSON();
+$('#design_image').val(att.url);
+$('#ticket_width').val(att.width);
+$('#ticket_height').val(att.height);
+});
+frame.open();
+});
+}
 });

--- a/includes/class-takamoa-papi-integration-activator.php
+++ b/includes/class-takamoa-papi-integration-activator.php
@@ -85,6 +85,22 @@ class Takamoa_Papi_Integration_Activator
 
 				dbDelta($sql_tickets);
 
+			// Designs table
+			$designs_table = $wpdb->prefix . 'takamoa_papi_designs';
+
+			$sql_designs = "CREATE TABLE $designs_table (
+				id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+				image_url TEXT NOT NULL,
+				ticket_width INT NOT NULL,
+				ticket_height INT NOT NULL,
+				qrcode_size INT NOT NULL,
+				qrcode_top INT NOT NULL,
+				qrcode_left INT NOT NULL,
+				created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+			) $charset_collate;";
+
+			dbDelta($sql_designs);
+
 		// Options par défaut à créer
 		add_option('takamoa_papi_api_key', '');
 

--- a/includes/class-takamoa-papi-integration.php
+++ b/includes/class-takamoa-papi-integration.php
@@ -173,6 +173,7 @@ class Takamoa_Papi_Integration {
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 		$this->loader->add_action('admin_menu', $plugin_admin, 'add_menu');
 		$this->loader->add_action('admin_init', $plugin_admin, 'register_settings');
+		$this->loader->add_action('admin_post_takamoa_save_design', $plugin_admin, 'handle_save_design');
 		$this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
 		}
 


### PR DESCRIPTION
## Summary
- add database table for ticket design templates
- provide admin UI to add ticket designs with image, dimensions and QR placement
- integrate media library picker for selecting design images

## Testing
- `php -l includes/class-takamoa-papi-integration-activator.php`
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l includes/class-takamoa-papi-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4ad87f4b8832eb247d9d803ffb9c0