### PR TITLE
chore: bump plugin version to 0.0.3

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -376,6 +376,11 @@ class Takamoa_Papi_Integration_Admin
 			<?php
 	}
 
+	/**
+	 * Display the tickets management page.
+	 *
+	 * @since 0.0.3
+	 */
 	public function display_tickets_page()
 	{
 			global $wpdb;
@@ -412,6 +417,11 @@ class Takamoa_Papi_Integration_Admin
 				<?php
 	}
 
+	/**
+	 * Display the ticket designs management page.
+	 *
+	 * @since 0.0.3
+	 */
 	public function display_designs_page()
 	{
 			global $wpdb;
@@ -473,6 +483,11 @@ class Takamoa_Papi_Integration_Admin
 				<?php
 	}
 
+	/**
+	 * Handle saving a ticket design.
+	 *
+	 * @since 0.0.3
+	 */
 	public function handle_save_design()
 	{
 			check_admin_referer('takamoa_save_design');

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -1,3 +1,8 @@
+/**
+ * Admin scripts for ticket and design management.
+ *
+ * @since 0.0.3
+ */
 jQuery(document).ready(function ($) {
 	if ($('#takamoa-payments-table').length) {
 		var table = $('#takamoa-payments-table').DataTable({

--- a/includes/class-takamoa-papi-integration-activator.php
+++ b/includes/class-takamoa-papi-integration-activator.php
@@ -85,7 +85,8 @@ class Takamoa_Papi_Integration_Activator
 
 				dbDelta($sql_tickets);
 
-			// Designs table
+			// Designs table.
+			// @since 0.0.3
 			$designs_table = $wpdb->prefix . 'takamoa_papi_designs';
 
 			$sql_designs = "CREATE TABLE $designs_table (

--- a/includes/class-takamoa-papi-integration-functions.php
+++ b/includes/class-takamoa-papi-integration-functions.php
@@ -381,6 +381,11 @@ class Takamoa_Papi_Integration_Functions
 		wp_send_json_success(['message' => 'Notification envoyée.']);
 	}
 
+	/**
+	 * AJAX handler to generate a ticket PDF from a design.
+	 *
+	 * @since 0.0.3
+	 */
 	public function handle_generate_ticket_ajax()
 	{
 		check_ajax_referer('takamoa_papi_nonce', 'nonce');

--- a/includes/class-takamoa-papi-integration.php
+++ b/includes/class-takamoa-papi-integration.php
@@ -79,7 +79,7 @@ class Takamoa_Papi_Integration {
 		if ( defined( 'TAKAMOA_PAPI_INTEGRATION_VERSION' ) ) {
 			$this->version = TAKAMOA_PAPI_INTEGRATION_VERSION;
 		} else {
-			$this->version = '0.0.1';
+			$this->version = '0.0.3';
 		}
 		$this->plugin_name = 'takamoa-papi-integration';
 		$this->load_dependencies();

--- a/takamoa-papi-integration.php
+++ b/takamoa-papi-integration.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Takamoa Papi Integration
  * Plugin URI:        https://nexa.takamoa.com/nos-realisations/
  * Description:       Easily generate and track payment links via Papi.mg directly from your WordPress site. Supports MVOLA, Orange Money, Airtel Money, and BRED. Includes real-time status tracking and customizable forms.
- * Version:           0.0.1
+ * Version:           0.0.3
  * Author:            Nexa by Takamoa
  * Author URI:        https://nexa.takamoa.com/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 0.0.1 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAKAMOA_PAPI_INTEGRATION_VERSION', '0.0.1' );
+define( 'TAKAMOA_PAPI_INTEGRATION_VERSION', '0.0.3' );
 /**
  * The code that runs during plugin activation.
  * This action is documented in includes/class-takamoa-papi-integration-activator.php


### PR DESCRIPTION
## Summary
- bump plugin version to 0.0.3
- annotate ticket and design management features with version 0.0.3
- enforce tab-based indentation across admin and integration classes

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l includes/class-takamoa-papi-integration-activator.php`
- `php -l includes/class-takamoa-papi-integration-functions.php`
- `php -l includes/class-takamoa-papi-integration.php`
- `php -l takamoa-papi-integration.php`
- `node --check admin/js/takamoa-papi-integration-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a57155086c832ebfe25e4bc723f933