### PR TITLE
Persist form data without auto payment

### DIFF
--- a/public/css/takamoa-papi-integration-public.css
+++ b/public/css/takamoa-papi-integration-public.css
@@ -74,7 +74,6 @@
 }
 
 .takamoa-papi-link {
-	color: #0073aa;
 	text-decoration: underline;
 	font-weight: bold;
 }
@@ -83,7 +82,7 @@
 	width: 30px;
 	height: 30px;
 	border: 4px solid #ccc;
-	border-top: 4px solid #007cba;
+	border-top: 4px solid #000000;
 	border-radius: 50%;
 	animation: spin 1s linear infinite;
 }


### PR DESCRIPTION
## Summary
- Always send form data to server even when payment="no"
- Only auto-open payment link for payment="yes" and show success message for payment="no"
- Use tab indentation, remove unused variable in public form script

## Testing
- `node --check public/js/takamoa-papi-form.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a57c7e6bac832e9b70fab02033ff4d