### PR TITLE
Corriger interactions et génération de billets

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -351,9 +351,8 @@ class Takamoa_Papi_Integration_Admin
 						</div>
 					</div>
 				</div>
-			</div>
 		<div class="modal fade" id="ticketModal" tabindex="-1" aria-hidden="true">
-			<div class="modal-dialog">
+			<div class="modal-dialog modal-dialog-centered modal-lg modal-fullscreen-sm-down">
 				<div class="modal-content">
 					<div class="modal-header">
 						<h5 class="modal-title">Générer un billet</h5>
@@ -367,11 +366,13 @@ class Takamoa_Papi_Integration_Admin
 						</select>
 					</div>
 					<div class="modal-footer">
-						<button type="button" id="generate-ticket-btn" class="button button-primary">Générer</button>
+						<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
+						<button type="button" id="generate-ticket-btn" class="btn btn-primary">Générer</button>
 					</div>
 				</div>
 			</div>
 		</div>
+</div>
 		</div>
 			<?php
 	}

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -32,7 +32,10 @@ jQuery(document).ready(function ($) {
 		$('#takamoa-payments-table tbody').on(
 			'click',
 			'tr.payment-row',
-			function () {
+			function (e) {
+				if ($(e.target).closest('button').length) {
+					return;
+				}
 				var row = $(this);
 				$('#modal-reference').text(row.data('reference'));
 				$('#modal-name').text(row.data('client'));
@@ -80,7 +83,7 @@ jQuery(document).ready(function ($) {
 			);
 		});
 
-		$(document).on('click', '.takamoa-notify', function (e) {
+		$('.takamoa-notify').on('click', function (e) {
 			e.stopPropagation();
 			var btn = $(this);
 			var row = btn.closest('tr');
@@ -98,7 +101,7 @@ jQuery(document).ready(function ($) {
 					);
 				})
 				.fail(function () {
-					alert('Erreur lors de l\'envoi de la notification');
+					alert("Erreur lors de l'envoi de la notification");
 				})
 				.always(function () {
 					btn.prop('disabled', false);
@@ -106,7 +109,7 @@ jQuery(document).ready(function ($) {
 		});
 
 		var currentRef = '';
-		$(document).on('click', '.takamoa-generate-ticket', function (e) {
+		$('.takamoa-generate-ticket').on('click', function (e) {
 			e.stopPropagation();
 			currentRef = $(this).closest('tr').data('reference');
 			var modal = new bootstrap.Modal(document.getElementById('ticketModal'));

--- a/includes/class-takamoa-papi-integration-functions.php
+++ b/includes/class-takamoa-papi-integration-functions.php
@@ -431,10 +431,16 @@ class Takamoa_Papi_Integration_Functions
 		$design_path = str_replace($upload['baseurl'], $upload['basedir'], $design->image_url);
 		$file = $dir . '/billet-' . $reference . '.pdf';
 		
-		$pdf = new \FPDF('P', 'pt', [$design->ticket_width, $design->ticket_height]);
+		$factor = 72 / 96;
+		$width = $design->ticket_width * $factor;
+		$height = $design->ticket_height * $factor;
+		$qrSize = $design->qrcode_size * $factor;
+		$qrTop = $design->qrcode_top * $factor;
+		$qrLeft = $design->qrcode_left * $factor;
+		$pdf = new \FPDF('P', 'pt', [$width, $height]);
 		$pdf->AddPage();
-		$pdf->Image($design_path, 0, 0, $design->ticket_width, $design->ticket_height);
-		$pdf->Image($qr_path, $design->qrcode_left, $design->qrcode_top, $design->qrcode_size, $design->qrcode_size);
+		$pdf->Image($design_path, 0, 0, $width, $height);
+		$pdf->Image($qr_path, $qrLeft, $qrTop, $qrSize, $qrSize);
 		$pdf->Output('F', $file);
 		@unlink($qr_path);
 		


### PR DESCRIPTION
## Résumé
- Empêche l'ouverture du modal de paiement lors des clics sur les boutons d'action
- Aligne le design du modal de génération de billet sur celui des détails de paiement
- Ajuste la génération PDF pour respecter la taille de l'image de billet

## Tests
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l includes/class-takamoa-papi-integration-functions.php`
- `npm test` *(échec : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68a586080a58832ea8af6669f8db3c58