### PR TITLE
Add dropdown actions for payment list

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -290,14 +290,20 @@ class Takamoa_Papi_Integration_Admin
 						<td><?= number_format($row->amount, 0, '', ' ') ?> MGA</td>
 						<td><?= esc_html($row->payment_status) ?></td>
 						<td><?= esc_html($row->payment_method ?: '—') ?></td>
-						<td><?= esc_html($row->created_at) ?></td>
-						<td>
-					<div class="btn-group" role="group">
-						<button type="button" class="button takamoa-notify">Notifier</button>
-						<button type="button" class="button takamoa-generate-ticket">Générer un billet</button>
-					</div>
-				</td>
-					</tr>
+					       <td><?= esc_html($row->created_at) ?></td>
+					       <td>
+						       <div class="btn-group">
+							       <button type="button" class="btn btn-sm btn-secondary dropdown-toggle takamoa-action-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+								       <i class="fa fa-cog"></i>
+							       </button>
+							       <ul class="dropdown-menu">
+								       <li><button type="button" class="dropdown-item takamoa-notify">Notifier</button></li>
+								       <li><button type="button" class="dropdown-item takamoa-generate-ticket">Générer un billet</button></li>
+								       <li><button type="button" class="dropdown-item takamoa-details">Détails</button></li>
+							       </ul>
+						       </div>
+					       </td>
+				       </tr>
 			<?php endforeach; ?>
 				</tbody>
 			</table>

--- a/admin/css/takamoa-papi-integration-admin.css
+++ b/admin/css/takamoa-papi-integration-admin.css
@@ -19,7 +19,11 @@
 
 /* Payments table */
 .payment-row {
-	cursor: pointer;
+	cursor: default;
+}
+
+.takamoa-action-toggle::after {
+	display: none;
 }
 
 /* DataTables custom styling */

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -29,52 +29,46 @@ jQuery(document).ready(function ($) {
 			.find('.dataTables_length label, .dataTables_filter label')
 			.addClass('d-flex align-items-center gap-2 mb-0');
 
-		$('#takamoa-payments-table tbody').on(
-			'click',
-			'tr.payment-row',
-			function (e) {
-				if ($(e.target).closest('button').length) {
-					return;
-				}
-				var row = $(this);
-				$('#modal-reference').text(row.data('reference'));
-				$('#modal-name').text(row.data('client'));
-				$('#modal-email').text(row.data('email') || '—');
-				$('#modal-phone').text(row.data('phone') || '—');
-				$('#modal-amount').text(row.data('amount'));
-				$('#modal-status').text(row.data('status'));
-				$('#modal-method').text(row.data('method'));
-				$('#modal-date').text(row.data('date'));
-				$('#modal-description').text(row.data('description') || '—');
-				$('#modal-id').text(row.data('id'));
-				$('#modal-provider').text(row.data('provider') || '—');
-				$('#modal-success-url').text(row.data('successUrl') || '—');
-				$('#modal-failure-url').text(row.data('failureUrl') || '—');
-				$('#modal-notification-url').text(row.data('notificationUrl') || '—');
-				$('#modal-link-creation').text(row.data('linkCreation') || '—');
-				$('#modal-link-expiration').text(row.data('linkExpiration') || '—');
-				$('#modal-payment-link').text(row.data('paymentLink') || '—');
-				$('#modal-currency').text(row.data('currency') || '—');
-				$('#modal-fee').text(row.data('fee') || '—');
-				$('#modal-notification-token').text(
-					row.data('notificationToken') || '—',
-				);
-				$('#modal-test-mode').text(row.data('isTestMode') ? 'Yes' : 'No');
-				$('#modal-test-reason').text(row.data('testReason') || '—');
-				$('#modal-raw-request').text(row.data('rawRequest') || '—');
-				$('#modal-raw-response').text(row.data('rawResponse') || '—');
-				$('#modal-raw-notification').text(row.data('rawNotification') || '—');
-				$('#modal-updated-at').text(row.data('updatedAt') || '—');
+		$('#takamoa-payments-table').on('click', '.takamoa-details', function (e) {
+			e.stopPropagation();
+			var row = $(this).closest('tr');
+			$('#modal-reference').text(row.data('reference'));
+			$('#modal-name').text(row.data('client'));
+			$('#modal-email').text(row.data('email') || '—');
+			$('#modal-phone').text(row.data('phone') || '—');
+			$('#modal-amount').text(row.data('amount'));
+			$('#modal-status').text(row.data('status'));
+			$('#modal-method').text(row.data('method'));
+			$('#modal-date').text(row.data('date'));
+			$('#modal-description').text(row.data('description') || '—');
+			$('#modal-id').text(row.data('id'));
+			$('#modal-provider').text(row.data('provider') || '—');
+			$('#modal-success-url').text(row.data('successUrl') || '—');
+			$('#modal-failure-url').text(row.data('failureUrl') || '—');
+			$('#modal-notification-url').text(row.data('notificationUrl') || '—');
+			$('#modal-link-creation').text(row.data('linkCreation') || '—');
+			$('#modal-link-expiration').text(row.data('linkExpiration') || '—');
+			$('#modal-payment-link').text(row.data('paymentLink') || '—');
+			$('#modal-currency').text(row.data('currency') || '—');
+			$('#modal-fee').text(row.data('fee') || '—');
+			$('#modal-notification-token').text(
+				row.data('notificationToken') || '—',
+			);
+			$('#modal-test-mode').text(row.data('isTestMode') ? 'Yes' : 'No');
+			$('#modal-test-reason').text(row.data('testReason') || '—');
+			$('#modal-raw-request').text(row.data('rawRequest') || '—');
+			$('#modal-raw-response').text(row.data('rawResponse') || '—');
+			$('#modal-raw-notification').text(row.data('rawNotification') || '—');
+			$('#modal-updated-at').text(row.data('updatedAt') || '—');
 
-				$('#modal-extra-info').addClass('d-none');
-				$('#toggle-more-info').text('Show more');
+			$('#modal-extra-info').addClass('d-none');
+			$('#toggle-more-info').text('Show more');
 
-				var modal = new bootstrap.Modal(
-					document.getElementById('paymentModal'),
-				);
-				modal.show();
-			},
-		);
+			var modal = new bootstrap.Modal(
+				document.getElementById('paymentModal'),
+			);
+			modal.show();
+		});
 
 		$('#toggle-more-info').on('click', function () {
 			$('#modal-extra-info').toggleClass('d-none');


### PR DESCRIPTION
## Summary
- use a single gear button with dropdown actions in payment list
- move payment details modal to new "Détails" action
- tweak table styling to remove row click behavior
- switch admin assets to tab-based indentation

## Testing
- `npm test` (fails: Could not read package.json)
- `php -l admin/class-takamoa-papi-integration-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a58e1dba38832eb70a13b90183bac1