### PR TITLE
Improve scanner page layout and QR code handling

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -502,16 +502,35 @@ class Takamoa_Papi_Integration_Admin
 	/**
 	* Display the ticket scanner page.
 	*/
-	public function display_scanner_page()
-	{
-			?>
-			<div class="wrap text-center">
-					<h1>Scanner billets</h1>
-					<div id="qr-reader"></div>
-					<div id="scan-result" class="mt-3"></div>
-			</div>
-			<?php
-	}
+        public function display_scanner_page()
+        {
+                        ?>
+                        <style>
+                        #wpadminbar,
+                        #adminmenumain,
+                        #adminmenuback,
+                        #adminmenuwrap {
+                                        display: none;
+                        }
+                        #wpcontent,
+                        #wpfooter {
+                                        margin-left: 0;
+                        }
+                        #takamoa-scanner-home {
+                                        position: fixed;
+                                        top: 20px;
+                                        left: 20px;
+                                        z-index: 999;
+                        }
+                        </style>
+                        <div class="wrap text-center">
+                                        <a href="<?= esc_url(admin_url()); ?>" class="button button-secondary" id="takamoa-scanner-home">Home</a>
+                                        <h1>Scanner billets</h1>
+                                        <div id="qr-reader"></div>
+                                        <div id="scan-result" class="mt-3"></div>
+                        </div>
+                        <?php
+        }
 
 	/**
 	* Handle saving a ticket design.

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -198,35 +198,37 @@ jQuery(document).ready(function ($) {
 			frame.open();
 		});
 	}
-	if ($('#qr-reader').length) {
-		var scanResult = $('#scan-result');
-		var scanner = new Html5Qrcode('qr-reader');
-		function startScanner() {
-			scanResult.empty();
-			scanner.start(
-				{ facingMode: 'environment' },
-				{ fps: 10, qrbox: 250 },
-				function (decodedText) {
-					scanner.stop().then(function () {
-						$.post(takamoaAjax.ajaxurl, {
-							action: 'takamoa_scan_ticket',
-							nonce: takamoaAjax.nonce,
-							reference: decodedText
-						}).done(function (res) {
-							if (res.success) {
-								scanResult.html('<div class="card"><div class="card-body"><h5>' + res.data.name + '</h5><p>Email: ' + (res.data.email || '—') + '<br>Téléphone: ' + (res.data.phone || '—') + '<br>Entreprise: ' + (res.data.description || '—') + '</p></div></div>');
-							} else {
-								scanResult.html('<div class="alert alert-danger">' + (res.data && res.data.message ? res.data.message : 'Billet introuvable') + '</div>');
-							}
-							startScanner();
-						}).fail(function () {
-							scanResult.html('<div class="alert alert-danger">Erreur de connexion</div>');
-							startScanner();
-						});
-					});
-				}
-			);
-		}
-		startScanner();
-	}
+        if ($('#qr-reader').length) {
+                var scanResult = $('#scan-result');
+                var scanner = new Html5Qrcode('qr-reader');
+                var processing = false;
+                scanner.start(
+                        { facingMode: 'environment' },
+                        { fps: 10, qrbox: 250 },
+                        function (decodedText) {
+                                if (processing) return;
+                                processing = true;
+                                scanner.pause(true);
+                                $.post(takamoaAjax.ajaxurl, {
+                                        action: 'takamoa_scan_ticket',
+                                        nonce: takamoaAjax.nonce,
+                                        reference: decodedText
+                                }).done(function (res) {
+                                        if (res.success) {
+                                                scanResult.html('<div class="card"><div class="card-body"><h5>' + res.data.name + '</h5><p>Email: ' + (res.data.email || '—') + '<br>Téléphone: ' + (res.data.phone || '—') + '<br>Entreprise: ' + (res.data.description || '—') + '</p></div></div>');
+                                        } else {
+                                                scanResult.html('<div class="alert alert-danger">' + (res.data && res.data.message ? res.data.message : 'Billet introuvable') + '</div>');
+                                        }
+                                }).fail(function () {
+                                        scanResult.html('<div class="alert alert-danger">Erreur de connexion</div>');
+                                }).always(function () {
+                                        setTimeout(function () {
+                                                scanResult.empty();
+                                                processing = false;
+                                                scanner.resume();
+                                        }, 2000);
+                                });
+                        }
+                );
+        }
 });


### PR DESCRIPTION
## Summary
- Hide WordPress admin menus on the ticket scanner page and add a Home button
- Replace stop/start loop with pause/resume to avoid QR scanner flicker

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `node --check admin/js/takamoa-papi-integration-admin.js`

------
https://chatgpt.com/codex/tasks/task_e_68a5b01e4c20832ebeba815e6a6d64b2