### PR TITLE
Improve scanner page layout and QR code handling

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -41,7 +41,7 @@ class Takamoa_Papi_Integration_Admin
 	{
 		if (strpos(get_current_screen()->id, $this->plugin_name) !== false) {
 			wp_enqueue_script('datatables-script', 'https://cdn.datatables.net/2.0.8/js/dataTables.min.js', array('jquery'), null, true);
-                       wp_enqueue_script('html5-qrcode', plugin_dir_url(__FILE__) . 'js/html5-qrcode.min.js', array(), '2.3.8', true);
+		       wp_enqueue_script('html5-qrcode', plugin_dir_url(__FILE__) . 'js/html5-qrcode.min.js', array(), '2.3.8', true);
 						wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/takamoa-papi-integration-admin.js', array('jquery', 'datatables-script', 'html5-qrcode'), $this->version, true);
 						wp_localize_script($this->plugin_name, 'takamoaAjax', array(
 								'ajaxurl' => admin_url('admin-ajax.php'),
@@ -504,13 +504,33 @@ class Takamoa_Papi_Integration_Admin
 	*/
 	public function display_scanner_page()
 	{
-			?>
-			<div class="wrap text-center">
-					<h1>Scanner billets</h1>
-					<div id="qr-reader"></div>
-					<div id="scan-result" class="mt-3"></div>
-			</div>
-			<?php
+	?>
+	<style>
+	#wpadminbar,
+	#adminmenumain,
+	#adminmenuback,
+	#adminmenuwrap,
+	.notice {
+	display: none;
+	}
+	#wpcontent,
+	#wpfooter {
+	margin-left: 0;
+	}
+	#takamoa-scanner-home {
+	position: fixed;
+	top: 20px;
+	left: 20px;
+	z-index: 999;
+	}
+	</style>
+	<div class="wrap text-center">
+	<a href="<?= esc_url(admin_url()); ?>" class="button button-secondary" id="takamoa-scanner-home">Home</a>
+	<h1>Scanner billets</h1>
+	<div id="qr-reader"></div>
+	<div id="scan-result" class="mt-3"></div>
+	</div>
+	<?php
 	}
 
 	/**

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -201,32 +201,26 @@ jQuery(document).ready(function ($) {
 	if ($('#qr-reader').length) {
 		var scanResult = $('#scan-result');
 		var scanner = new Html5Qrcode('qr-reader');
-		function startScanner() {
-			scanResult.empty();
-			scanner.start(
-				{ facingMode: 'environment' },
-				{ fps: 10, qrbox: 250 },
-				function (decodedText) {
-					scanner.stop().then(function () {
-						$.post(takamoaAjax.ajaxurl, {
-							action: 'takamoa_scan_ticket',
-							nonce: takamoaAjax.nonce,
-							reference: decodedText
-						}).done(function (res) {
-							if (res.success) {
-								scanResult.html('<div class="card"><div class="card-body"><h5>' + res.data.name + '</h5><p>Email: ' + (res.data.email || '—') + '<br>Téléphone: ' + (res.data.phone || '—') + '<br>Entreprise: ' + (res.data.description || '—') + '</p></div></div>');
-							} else {
-								scanResult.html('<div class="alert alert-danger">' + (res.data && res.data.message ? res.data.message : 'Billet introuvable') + '</div>');
-							}
-							startScanner();
-						}).fail(function () {
-							scanResult.html('<div class="alert alert-danger">Erreur de connexion</div>');
-							startScanner();
-						});
-					});
-				}
-			);
-		}
-		startScanner();
+		scanner.start(
+			{ facingMode: 'environment' },
+			{ fps: 10, qrbox: 250 },
+			function (decodedText) {
+				scanner.stop().catch(function () {});
+				$('#qr-reader').hide();
+				$.post(takamoaAjax.ajaxurl, {
+					action: 'takamoa_scan_ticket',
+					nonce: takamoaAjax.nonce,
+					reference: decodedText
+				}).done(function (res) {
+					if (res.success) {
+						scanResult.html('<div class="card"><div class="card-body"><h5>' + res.data.name + '</h5><p>Email: ' + (res.data.email || '—') + '<br>Téléphone: ' + (res.data.phone || '—') + '<br>Entreprise: ' + (res.data.description || '—') + '</p></div></div>');
+					} else {
+						scanResult.html('<div class="alert alert-danger">' + (res.data && res.data.message ? res.data.message : 'Billet introuvable') + '</div>');
+					}
+				}).fail(function () {
+					scanResult.html('<div class="alert alert-danger">Erreur de connexion</div>');
+				});
+			}
+		);
 	}
 });


### PR DESCRIPTION
## Summary
- Hide WordPress admin menus and notices on the ticket scanner page and keep a Home button for navigation
- Stop the QR scanner after a successful read and display ticket details

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `node --check admin/js/takamoa-papi-integration-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5b01e4c20832ebeba815e6a6d64b2