### PR TITLE
Stop scanner after first scan and hide notices

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -506,22 +506,25 @@ class Takamoa_Papi_Integration_Admin
         {
                         ?>
                         <style>
-                        #wpadminbar,
-                        #adminmenumain,
-                        #adminmenuback,
-                        #adminmenuwrap {
-                                        display: none;
-                        }
-                        #wpcontent,
-                        #wpfooter {
-                                        margin-left: 0;
-                        }
-                        #takamoa-scanner-home {
-                                        position: fixed;
-                                        top: 20px;
-                                        left: 20px;
-                                        z-index: 999;
-                        }
+			#wpadminbar,
+			#adminmenumain,
+			#adminmenuback,
+			#adminmenuwrap {
+				display: none;
+			}
+			.notice {
+					display: none;
+			}
+			#wpcontent,
+			#wpfooter {
+				margin-left: 0;
+			}
+			#takamoa-scanner-home {
+				position: fixed;
+				top: 20px;
+				left: 20px;
+				z-index: 999;
+			}
                         </style>
                         <div class="wrap text-center">
                                         <a href="<?= esc_url(admin_url()); ?>" class="button button-secondary" id="takamoa-scanner-home">Home</a>

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -1,8 +1,8 @@
 /**
- * Admin scripts for ticket and design management.
- *
- * @since 0.0.3
- */
+* Admin scripts for ticket and design management.
+*
+* @since 0.0.3
+*/
 jQuery(document).ready(function ($) {
 	if ($('#takamoa-payments-table').length) {
 		var table = $('#takamoa-payments-table').DataTable({
@@ -198,37 +198,33 @@ jQuery(document).ready(function ($) {
 			frame.open();
 		});
 	}
-        if ($('#qr-reader').length) {
-                var scanResult = $('#scan-result');
-                var scanner = new Html5Qrcode('qr-reader');
-                var processing = false;
-                scanner.start(
-                        { facingMode: 'environment' },
-                        { fps: 10, qrbox: 250 },
-                        function (decodedText) {
-                                if (processing) return;
-                                processing = true;
-                                scanner.pause(true);
-                                $.post(takamoaAjax.ajaxurl, {
-                                        action: 'takamoa_scan_ticket',
-                                        nonce: takamoaAjax.nonce,
-                                        reference: decodedText
-                                }).done(function (res) {
-                                        if (res.success) {
-                                                scanResult.html('<div class="card"><div class="card-body"><h5>' + res.data.name + '</h5><p>Email: ' + (res.data.email || '—') + '<br>Téléphone: ' + (res.data.phone || '—') + '<br>Entreprise: ' + (res.data.description || '—') + '</p></div></div>');
-                                        } else {
-                                                scanResult.html('<div class="alert alert-danger">' + (res.data && res.data.message ? res.data.message : 'Billet introuvable') + '</div>');
-                                        }
-                                }).fail(function () {
-                                        scanResult.html('<div class="alert alert-danger">Erreur de connexion</div>');
-                                }).always(function () {
-                                        setTimeout(function () {
-                                                scanResult.empty();
-                                                processing = false;
-                                                scanner.resume();
-                                        }, 2000);
-                                });
-                        }
-                );
-        }
+	if ($('#qr-reader').length) {
+		var scanResult = $('#scan-result');
+		var scanner = new Html5Qrcode('qr-reader');
+		var processing = false;
+		scanner.start(
+			{ facingMode: 'environment' },
+			{ fps: 10, qrbox: 250 },
+			function (decodedText) {
+				if (processing) return;
+				processing = true;
+				scanner.stop().then(function () {
+					$('#qr-reader').hide();
+				}).catch(function () {});
+				$.post(takamoaAjax.ajaxurl, {
+					action: 'takamoa_scan_ticket',
+					nonce: takamoaAjax.nonce,
+					reference: decodedText
+				}).done(function (res) {
+					if (res.success) {
+						scanResult.html('<div class="card"><div class="card-body"><h5>' + res.data.name + '</h5><p>Email: ' + (res.data.email || '—') + '<br>Téléphone: ' + (res.data.phone || '—') + '<br>Entreprise: ' + (res.data.description || '—') + '</p></div></div>');
+					} else {
+						scanResult.html('<div class="alert alert-danger">' + (res.data && res.data.message ? res.data.message : 'Billet introuvable') + '</div>');
+					}
+				}).fail(function () {
+					scanResult.html('<div class="alert alert-danger">Erreur de connexion</div>');
+				});
+			}
+		);
+	}
 });


### PR DESCRIPTION
## Summary
- Hide WordPress admin notices on the scanner page
- Stop HTML5 QR Code scanner after a scan and show ticket details

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `node --check admin/js/takamoa-papi-integration-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5b423c518832eb8815a0799ba9db2