### PR TITLE
Display QR content without AJAX lookup

### DIFF
--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -202,29 +202,24 @@ jQuery(document).ready(function ($) {
 		var scanResult = $('#scan-result');
 		var scanner = new Html5Qrcode('qr-reader');
 		var processing = false;
-		scanner.start(
-			{ facingMode: 'environment' },
-			{ fps: 10, qrbox: 250 },
-			function (decodedText) {
-				if (processing) return;
-				processing = true;
-				scanner.stop().then(function () {
-					$('#qr-reader').hide();
-				}).catch(function () {});
-				$.post(takamoaAjax.ajaxurl, {
-					action: 'takamoa_scan_ticket',
-					nonce: takamoaAjax.nonce,
-					reference: decodedText
-				}).done(function (res) {
-					if (res.success) {
-						scanResult.html('<div class="card"><div class="card-body"><h5>' + res.data.name + '</h5><p>Email: ' + (res.data.email || '—') + '<br>Téléphone: ' + (res.data.phone || '—') + '<br>Entreprise: ' + (res.data.description || '—') + '</p></div></div>');
-					} else {
-						scanResult.html('<div class="alert alert-danger">' + (res.data && res.data.message ? res.data.message : 'Billet introuvable') + '</div>');
-					}
-				}).fail(function () {
-					scanResult.html('<div class="alert alert-danger">Erreur de connexion</div>');
-				});
-			}
-		);
+               scanner.start(
+                       { facingMode: 'environment' },
+                       { fps: 10, qrbox: 250 },
+                       function (decodedText) {
+                               if (processing) return;
+                               processing = true;
+                               scanner
+                                       .stop()
+                                       .then(function () {
+                                               $('#qr-reader').hide();
+                                               scanResult.html(
+                                                       '<div class="card"><div class="card-body">' +
+                                                               decodedText +
+                                                               '</div></div>',
+                                               );
+                                       })
+                                       .catch(function () {});
+                       }
+               );
 	}
 });


### PR DESCRIPTION
## Summary
- Stop automatic AJAX lookup when scanning QR codes in admin area
- After scanning, hide the reader and show the decoded QR content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b7f80990832ebb845e48d1268752