### PR TITLE
chore: bump plugin version to 0.0.5

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -93,14 +93,14 @@ class Takamoa_Papi_Integration_Admin
 					$this->plugin_name . '-design',
 					array($this, 'display_designs_page')
 				);
-					add_submenu_page(
-					$this->plugin_name,
-					'Scanner billets',
-					'Scanner billets',
-					'manage_options',
-					$this->plugin_name . '-scanner',
-					array($this, 'display_scanner_page')
-					);
+                                       add_submenu_page(
+                                       $this->plugin_name,
+                                       'Scanner billets',
+                                       'Scanner billets',
+                                       'manage_options',
+                                       $this->plugin_name . '-scanner',
+                                       array($this, 'display_scanner_page')
+                                       ); // @since 0.0.5
 
 
 				add_submenu_page(
@@ -499,11 +499,13 @@ class Takamoa_Papi_Integration_Admin
 				<?php
 	}
 
-	/**
-	* Display the ticket scanner page.
-	*/
-        public function display_scanner_page()
-        {
+       /**
+       * Display the ticket scanner page.
+       *
+       * @since 0.0.5
+       */
+       public function display_scanner_page()
+       {
                         ?>
                         <style>
 			#wpadminbar,

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -198,8 +198,9 @@ jQuery(document).ready(function ($) {
 			frame.open();
 		});
 	}
-	if ($('#qr-reader').length) {
-		var scanResult = $('#scan-result');
+       if ($('#qr-reader').length) {
+               // QR code scanning feature @since 0.0.5
+               var scanResult = $('#scan-result');
 		var scanner = new Html5Qrcode('qr-reader');
 		var processing = false;
 		scanner.start(

--- a/includes/class-takamoa-papi-integration-functions.php
+++ b/includes/class-takamoa-papi-integration-functions.php
@@ -485,11 +485,13 @@ class Takamoa_Papi_Integration_Functions
 
 		wp_send_json_success(['url' => $url]);
 	}
-	/**
-	 * AJAX handler to verify a ticket reference and return ticket info.
-	 */
-	public function handle_scan_ticket_ajax()
-	{
+       /**
+         * AJAX handler to verify a ticket reference and return ticket info.
+         *
+         * @since 0.0.5
+         */
+        public function handle_scan_ticket_ajax()
+        {
 			check_ajax_referer('takamoa_papi_nonce', 'nonce');
 
 			$reference = sanitize_text_field($_POST['reference'] ?? '');

--- a/includes/class-takamoa-papi-integration.php
+++ b/includes/class-takamoa-papi-integration.php
@@ -176,7 +176,7 @@ class Takamoa_Papi_Integration {
 		$this->loader->add_action('admin_post_takamoa_save_design', $plugin_admin, 'handle_save_design');
 		$this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
 		$this->loader->add_action('wp_ajax_takamoa_generate_ticket', $this->functions, 'handle_generate_ticket_ajax');
-		$this->loader->add_action('wp_ajax_takamoa_scan_ticket', $this->functions, 'handle_scan_ticket_ajax');
+               $this->loader->add_action('wp_ajax_takamoa_scan_ticket', $this->functions, 'handle_scan_ticket_ajax'); // @since 0.0.5
 		}
 
 	/**

--- a/takamoa-papi-integration.php
+++ b/takamoa-papi-integration.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Takamoa Papi Integration
  * Plugin URI:        https://nexa.takamoa.com/nos-realisations/
  * Description:       Easily generate and track payment links via Papi.mg directly from your WordPress site. Supports MVOLA, Orange Money, Airtel Money, and BRED. Includes real-time status tracking and customizable forms.
- * Version:           0.0.3
+ * Version:           0.0.5
  * Author:            Nexa by Takamoa
  * Author URI:        https://nexa.takamoa.com/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 0.0.1 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAKAMOA_PAPI_INTEGRATION_VERSION', '0.0.3' );
+define( 'TAKAMOA_PAPI_INTEGRATION_VERSION', '0.0.5' );
 /**
  * The code that runs during plugin activation.
  * This action is documented in includes/class-takamoa-papi-integration-activator.php


### PR DESCRIPTION
## Summary
- bump plugin version to 0.0.5
- document QR code scanning functions with `@since 0.0.5` annotations

## Testing
- `php -l takamoa-papi-integration.php`
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l includes/class-takamoa-papi-integration.php`
- `php -l includes/class-takamoa-papi-integration-functions.php`
- `node --check admin/js/takamoa-papi-integration-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5bf982428832e88ae0f4025073f90