### PR TITLE
Gracefully handle missing Html5Qrcode library

### DIFF
--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -200,13 +200,17 @@ jQuery(document).ready(function ($) {
 	}
        if ($('#qr-reader').length) {
                // QR code scanning feature @since 0.0.5
+               if (typeof Html5Qrcode === 'undefined') {
+                       console.error('Html5Qrcode library not loaded');
+                       return;
+               }
                var scanResult = $('#scan-result');
-		var scanner = new Html5Qrcode('qr-reader');
-		var processing = false;
-		scanner.start(
-			{ facingMode: 'environment' },
-			{ fps: 10, qrbox: 250 },
-			function (decodedText) {
+                var scanner = new Html5Qrcode('qr-reader');
+                var processing = false;
+                scanner.start(
+                        { facingMode: 'environment' },
+                        { fps: 10, qrbox: 250 },
+                        function (decodedText) {
 				if (processing) return;
 				processing = true;
 				scanner.stop().then(function () {


### PR DESCRIPTION
## Summary
- avoid scanner crash when Html5Qrcode script fails to load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c244b878832e84cad8cc71442a4f