### PR TITLE
feat: ticket validation and rescan

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -531,11 +531,12 @@ class Takamoa_Papi_Integration_Admin
                         <div class="wrap text-center">
                                         <a href="<?= esc_url(admin_url()); ?>" class="button button-secondary" id="takamoa-scanner-home">Home</a>
                                         <h1>Scanner billets</h1>
-                                        <div id="qr-reader"></div>
-                                        <div id="scan-result" class="mt-3"></div>
-                        </div>
-                        <?php
-        }
+					<div id="qr-reader"></div>
+					<div id="scan-result" class="mt-3"></div>
+					<button id="rescan-btn" class="button button-primary mt-3">Re-scan</button>
+				</div>
+<?php
+}
 
 	/**
 	* Handle saving a ticket design.

--- a/admin/css/takamoa-papi-integration-admin.css
+++ b/admin/css/takamoa-papi-integration-admin.css
@@ -103,3 +103,6 @@
 	max-width: 400px;
 	margin: 1rem auto;
 }
+#rescan-btn {
+	display: none;
+}

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -16,19 +16,19 @@ jQuery(document).ready(function ($) {
 				searchPlaceholder: 'Search…',
 			},
 		});
-
+		
 		var wrapper = $('#takamoa-payments-table_wrapper');
 		wrapper
-			.find('.dataTables_length select')
-			.addClass('form-select form-select-sm');
+		.find('.dataTables_length select')
+		.addClass('form-select form-select-sm');
 		wrapper
-			.find('.dataTables_filter input')
-			.addClass('form-control form-control-sm')
-			.attr('placeholder', 'Search…');
+		.find('.dataTables_filter input')
+		.addClass('form-control form-control-sm')
+		.attr('placeholder', 'Search…');
 		wrapper
-			.find('.dataTables_length label, .dataTables_filter label')
-			.addClass('d-flex align-items-center gap-2 mb-0');
-
+		.find('.dataTables_length label, .dataTables_filter label')
+		.addClass('d-flex align-items-center gap-2 mb-0');
+		
 		$('#takamoa-payments-table').on('click', '.takamoa-details', function (e) {
 			e.stopPropagation();
 			var row = $(this).closest('tr');
@@ -52,180 +52,224 @@ jQuery(document).ready(function ($) {
 			$('#modal-currency').text(row.data('currency') || '—');
 			$('#modal-fee').text(row.data('fee') || '—');
 			$('#modal-notification-token').text(
-				row.data('notificationToken') || '—',
-			);
-			$('#modal-test-mode').text(row.data('isTestMode') ? 'Yes' : 'No');
-			$('#modal-test-reason').text(row.data('testReason') || '—');
-			$('#modal-raw-request').text(row.data('rawRequest') || '—');
-			$('#modal-raw-response').text(row.data('rawResponse') || '—');
-			$('#modal-raw-notification').text(row.data('rawNotification') || '—');
-			$('#modal-updated-at').text(row.data('updatedAt') || '—');
+			row.data('notificationToken') || '—',
+		);
+		$('#modal-test-mode').text(row.data('isTestMode') ? 'Yes' : 'No');
+		$('#modal-test-reason').text(row.data('testReason') || '—');
+		$('#modal-raw-request').text(row.data('rawRequest') || '—');
+		$('#modal-raw-response').text(row.data('rawResponse') || '—');
+		$('#modal-raw-notification').text(row.data('rawNotification') || '—');
+		$('#modal-updated-at').text(row.data('updatedAt') || '—');
+		
+		$('#modal-extra-info').addClass('d-none');
+		$('#toggle-more-info').text('Show more');
+		
+		var modal = new bootstrap.Modal(
+		document.getElementById('paymentModal'),
+	);
+	modal.show();
+});
 
-			$('#modal-extra-info').addClass('d-none');
-			$('#toggle-more-info').text('Show more');
+$('#toggle-more-info').on('click', function () {
+	$('#modal-extra-info').toggleClass('d-none');
+	$(this).text(
+	$('#modal-extra-info').hasClass('d-none') ? 'Show more' : 'Show less',
+);
+});
 
-			var modal = new bootstrap.Modal(
-				document.getElementById('paymentModal'),
-			);
-			modal.show();
-		});
+$('#takamoa-payments-table').on('click', '.takamoa-notify', function (e) {
+	e.stopPropagation();
+	var btn = $(this);
+	var row = btn.closest('tr');
+	btn.prop('disabled', true);
+	$.post(takamoaAjax.ajaxurl, {
+		action: 'takamoa_resend_payment_email',
+		nonce: takamoaAjax.nonce,
+		reference: row.data('reference'),
+	})
+	.done(function (res) {
+		alert(
+		res.data && res.data.message
+		? res.data.message
+		: 'Notification envoyée',
+	);
+})
+.fail(function () {
+	alert("Erreur lors de l'envoi de la notification");
+})
+.always(function () {
+	btn.prop('disabled', false);
+});
+});
 
-		$('#toggle-more-info').on('click', function () {
-			$('#modal-extra-info').toggleClass('d-none');
-			$(this).text(
-				$('#modal-extra-info').hasClass('d-none') ? 'Show more' : 'Show less',
-			);
-		});
+var currentRef = '';
+$('#takamoa-payments-table').on('click', '.takamoa-generate-ticket', function (e) {
+	e.stopPropagation();
+	currentRef = $(this).closest('tr').data('reference');
+	var modal = new bootstrap.Modal(document.getElementById('ticketModal'));
+	modal.show();
+});
 
-		$('#takamoa-payments-table').on('click', '.takamoa-notify', function (e) {
-			e.stopPropagation();
-			var btn = $(this);
-			var row = btn.closest('tr');
-			btn.prop('disabled', true);
-			$.post(takamoaAjax.ajaxurl, {
-				action: 'takamoa_resend_payment_email',
-				nonce: takamoaAjax.nonce,
-				reference: row.data('reference'),
-			})
-				.done(function (res) {
-					alert(
-						res.data && res.data.message
-							? res.data.message
-							: 'Notification envoyée',
-					);
-				})
-				.fail(function () {
-					alert("Erreur lors de l'envoi de la notification");
-				})
-				.always(function () {
-					btn.prop('disabled', false);
-				});
-		});
-
-		var currentRef = '';
-		$('#takamoa-payments-table').on('click', '.takamoa-generate-ticket', function (e) {
-			e.stopPropagation();
-			currentRef = $(this).closest('tr').data('reference');
-			var modal = new bootstrap.Modal(document.getElementById('ticketModal'));
-			modal.show();
-		});
-
-		$('#generate-ticket-btn').on('click', function () {
-			var btn = $(this);
-			var design = $('#ticket-design').val();
-			if (!design || !currentRef) {
-				return;
-			}
-			btn.prop('disabled', true);
-			$.post(takamoaAjax.ajaxurl, {
-				action: 'takamoa_generate_ticket',
-				nonce: takamoaAjax.nonce,
-				reference: currentRef,
-				design_id: design,
-			})
-				.done(function (res) {
-					if (res.success && res.data.url) {
-						if (confirm('Billet généré. Voulez-vous télécharger le billet ?')) {
-							window.open(res.data.url, '_blank');
-						} else {
-							window.location.href = takamoaAjax.ticketsPage;
-						}
-					} else {
-						alert(
-							res.data && res.data.message
-								? res.data.message
-								: 'Erreur lors de la génération',
-						);
-					}
-				})
-				.fail(function () {
-					alert('Erreur lors de la génération');
-				})
-				.always(function () {
-					btn.prop('disabled', false);
-					bootstrap.Modal.getInstance(
-						document.getElementById('ticketModal'),
-					).hide();
-				});
-		});
+$('#generate-ticket-btn').on('click', function () {
+	var btn = $(this);
+	var design = $('#ticket-design').val();
+	if (!design || !currentRef) {
+		return;
 	}
-
-	if ($('#takamoa-tickets-table').length) {
-		var ttable = $('#takamoa-tickets-table').DataTable({
-			pageLength: 10,
-			lengthMenu: [5, 10, 25, 50],
-			pagingType: 'full_numbers',
-			dom: '<"datatable-header d-flex justify-content-between align-items-center mb-3"lf>rt<"datatable-footer d-flex justify-content-between align-items-center mt-3"ip>',
-			language: {
-				lengthMenu: '_MENU_',
-				search: '',
-				searchPlaceholder: 'Search…',
-			},
-		});
-
-		var twrapper = $('#takamoa-tickets-table_wrapper');
-		twrapper
-			.find('.dataTables_length select')
-			.addClass('form-select form-select-sm');
-		twrapper
-			.find('.dataTables_filter input')
-			.addClass('form-control form-control-sm')
-			.attr('placeholder', 'Search…');
-		twrapper
-			.find('.dataTables_length label, .dataTables_filter label')
-			.addClass('d-flex align-items-center gap-2 mb-0');
-	}
-
-	if ($('#select_design_image').length) {
-		var frame;
-		$('#select_design_image').on('click', function (e) {
-			e.preventDefault();
-			if (frame) {
-				frame.open();
-				return;
+	btn.prop('disabled', true);
+	$.post(takamoaAjax.ajaxurl, {
+		action: 'takamoa_generate_ticket',
+		nonce: takamoaAjax.nonce,
+		reference: currentRef,
+		design_id: design,
+	})
+	.done(function (res) {
+		if (res.success && res.data.url) {
+			if (confirm('Billet généré. Voulez-vous télécharger le billet ?')) {
+				window.open(res.data.url, '_blank');
+			} else {
+				window.location.href = takamoaAjax.ticketsPage;
 			}
-			frame = wp.media({
-				title: 'Choisir une image',
-				button: { text: 'Utiliser cette image' },
-				multiple: false,
-			});
-			frame.on('select', function () {
-				var att = frame.state().get('selection').first().toJSON();
-				$('#design_image').val(att.url);
-				$('#ticket_width').val(att.width);
-				$('#ticket_height').val(att.height);
-			});
-			frame.open();
-		});
-	}
-       if ($('#qr-reader').length) {
-               // QR code scanning feature @since 0.0.5
-               var scanResult = $('#scan-result');
-		var scanner = new Html5Qrcode('qr-reader');
-		var processing = false;
-		scanner.start(
-			{ facingMode: 'environment' },
-			{ fps: 10, qrbox: 250 },
-			function (decodedText) {
-				if (processing) return;
-				processing = true;
-				scanner.stop().then(function () {
-					$('#qr-reader').hide();
-				}).catch(function () {});
-				$.post(takamoaAjax.ajaxurl, {
-					action: 'takamoa_scan_ticket',
-					nonce: takamoaAjax.nonce,
-					reference: decodedText
-				}).done(function (res) {
-					if (res.success) {
-						scanResult.html('<div class="card"><div class="card-body"><h5>' + res.data.name + '</h5><p>Email: ' + (res.data.email || '—') + '<br>Téléphone: ' + (res.data.phone || '—') + '<br>Entreprise: ' + (res.data.description || '—') + '</p></div></div>');
-					} else {
-						scanResult.html('<div class="alert alert-danger">' + (res.data && res.data.message ? res.data.message : 'Billet introuvable') + '</div>');
-					}
-				}).fail(function () {
-					scanResult.html('<div class="alert alert-danger">Erreur de connexion</div>');
-				});
-			}
+		} else {
+			alert(
+			res.data && res.data.message
+			? res.data.message
+			: 'Erreur lors de la génération',
 		);
 	}
+})
+.fail(function () {
+	alert('Erreur lors de la génération');
+})
+.always(function () {
+	btn.prop('disabled', false);
+	bootstrap.Modal.getInstance(
+	document.getElementById('ticketModal'),
+	).hide();
+});
+});
+}
+
+if ($('#takamoa-tickets-table').length) {
+	var ttable = $('#takamoa-tickets-table').DataTable({
+		pageLength: 10,
+		lengthMenu: [5, 10, 25, 50],
+		pagingType: 'full_numbers',
+		dom: '<"datatable-header d-flex justify-content-between align-items-center mb-3"lf>rt<"datatable-footer d-flex justify-content-between align-items-center mt-3"ip>',
+		language: {
+			lengthMenu: '_MENU_',
+			search: '',
+			searchPlaceholder: 'Search…',
+		},
+	});
+	
+	var twrapper = $('#takamoa-tickets-table_wrapper');
+	twrapper
+	.find('.dataTables_length select')
+	.addClass('form-select form-select-sm');
+	twrapper
+	.find('.dataTables_filter input')
+	.addClass('form-control form-control-sm')
+	.attr('placeholder', 'Search…');
+	twrapper
+	.find('.dataTables_length label, .dataTables_filter label')
+	.addClass('d-flex align-items-center gap-2 mb-0');
+}
+
+if ($('#select_design_image').length) {
+	var frame;
+	$('#select_design_image').on('click', function (e) {
+		e.preventDefault();
+		if (frame) {
+			frame.open();
+			return;
+		}
+		frame = wp.media({
+			title: 'Choisir une image',
+			button: { text: 'Utiliser cette image' },
+			multiple: false,
+		});
+		frame.on('select', function () {
+			var att = frame.state().get('selection').first().toJSON();
+			$('#design_image').val(att.url);
+			$('#ticket_width').val(att.width);
+			$('#ticket_height').val(att.height);
+		});
+		frame.open();
+	});
+}
+if ($('#qr-reader').length) {
+	// QR code scanning feature @since 0.0.5
+	var scanResult = $('#scan-result');
+	var rescanBtn = $('#rescan-btn');
+	var scanner = new Html5Qrcode('qr-reader');
+	var processing = false;
+	
+	function startScanner() {
+		processing = false;
+		scanner.start(
+		{ facingMode: 'environment' },
+		{ fps: 10, qrbox: 250 },
+		onScan
+	);
+}
+
+function onScan(decodedText) {
+	if (processing) return;
+	processing = true;
+	scanner.stop().then(function () {
+		$('#qr-reader').hide();
+	}).catch(function () {});
+	$.post(takamoaAjax.ajaxurl, {
+		action: 'takamoa_scan_ticket',
+		nonce: takamoaAjax.nonce,
+		reference: decodedText
+	}).done(function (res) {
+		if (res.success) {
+			var html = '<div class="card"><div class="card-body"><h5>' + res.data.name + '</h5><p>Email: ' + (res.data.email || '—') + '<br>Téléphone: ' + (res.data.phone || '—') + '<br>Entreprise: ' + (res.data.description || '—') + '<br>Status: <span class="ticket-status">' + res.data.status + '</span></p>';
+			if (res.data.status === 'GENERATED') {
+				html += '<button id="validate-ticket" data-ref="' + decodedText + '" class="button button-primary mt-2">Valider le billet</button>';
+			}
+			html += '</div></div>';
+			scanResult.html(html);
+		} else {
+			scanResult.html('<div class="alert alert-danger">' + (res.data && res.data.message ? res.data.message : 'Billet introuvable') + '</div>');
+		}
+		rescanBtn.show();
+	}).fail(function () {
+		scanResult.html('<div class="alert alert-danger">Erreur de connexion</div>');
+		rescanBtn.show();
+	});
+}
+
+startScanner();
+
+rescanBtn.on('click', function () {
+	scanResult.empty();
+	$(this).hide();
+	$('#qr-reader').show();
+	startScanner();
+});
+
+scanResult.on('click', '#validate-ticket', function () {
+	var btn = $(this);
+	btn.prop('disabled', true);
+	$.post(takamoaAjax.ajaxurl, {
+		action: 'takamoa_validate_ticket',
+		nonce: takamoaAjax.nonce,
+		reference: btn.data('ref')
+	}).done(function (res) {
+		if (res.success) {
+			scanResult.find('.ticket-status').text(res.data.status);
+			btn.remove();
+		} else {
+			alert(res.data && res.data.message ? res.data.message : 'Erreur lors de la validation');
+			btn.prop('disabled', false);
+		}
+	}).fail(function () {
+		alert('Erreur de connexion');
+		btn.prop('disabled', false);
+	});
+});
+}
 });

--- a/includes/class-takamoa-papi-integration.php
+++ b/includes/class-takamoa-papi-integration.php
@@ -168,7 +168,7 @@ class Takamoa_Papi_Integration {
 	private function define_admin_hooks() {
 
 		$plugin_admin = new Takamoa_Papi_Integration_Admin( $this->get_plugin_name(), $this->get_version(), $this->get_functions() );
-
+		
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 		$this->loader->add_action('admin_menu', $plugin_admin, 'add_menu');
@@ -176,8 +176,9 @@ class Takamoa_Papi_Integration {
 		$this->loader->add_action('admin_post_takamoa_save_design', $plugin_admin, 'handle_save_design');
 		$this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
 		$this->loader->add_action('wp_ajax_takamoa_generate_ticket', $this->functions, 'handle_generate_ticket_ajax');
-               $this->loader->add_action('wp_ajax_takamoa_scan_ticket', $this->functions, 'handle_scan_ticket_ajax'); // @since 0.0.5
-		}
+		$this->loader->add_action('wp_ajax_takamoa_scan_ticket', $this->functions, 'handle_scan_ticket_ajax'); // @since 0.0.5
+		$this->loader->add_action('wp_ajax_takamoa_validate_ticket', $this->functions, 'handle_validate_ticket_ajax'); // @since 0.0.6
+	}
 
 	/**
 	 * Register all of the hooks related to the public-facing functionality

--- a/takamoa-papi-integration.php
+++ b/takamoa-papi-integration.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Takamoa Papi Integration
  * Plugin URI:        https://nexa.takamoa.com/nos-realisations/
  * Description:       Easily generate and track payment links via Papi.mg directly from your WordPress site. Supports MVOLA, Orange Money, Airtel Money, and BRED. Includes real-time status tracking and customizable forms.
- * Version:           0.0.5
+ * Version:           0.0.6
  * Author:            Nexa by Takamoa
  * Author URI:        https://nexa.takamoa.com/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 0.0.1 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAKAMOA_PAPI_INTEGRATION_VERSION', '0.0.5' );
+define( 'TAKAMOA_PAPI_INTEGRATION_VERSION', '0.0.6' );
 /**
  * The code that runs during plugin activation.
  * This action is documented in includes/class-takamoa-papi-integration-activator.php


### PR DESCRIPTION
## Summary
- bump plugin to version 0.0.6
- show ticket status and allow validation from QR scanner
- add rescan support on scanner page

## Testing
- `php -l takamoa-papi-integration.php`
- `php -l includes/class-takamoa-papi-integration.php`
- `php -l includes/class-takamoa-papi-integration-functions.php`
- `php -l admin/class-takamoa-papi-integration-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5c8fe8adc832ea0aed0fa5fd257cb