### PR TITLE
chore: bump plugin version to 0.0.7

### DIFF
--- a/includes/class-takamoa-papi-integration.php
+++ b/includes/class-takamoa-papi-integration.php
@@ -79,7 +79,7 @@ class Takamoa_Papi_Integration {
 		if ( defined( 'TAKAMOA_PAPI_INTEGRATION_VERSION' ) ) {
 			$this->version = TAKAMOA_PAPI_INTEGRATION_VERSION;
 		} else {
-			$this->version = '0.0.3';
+			$this->version = '0.0.7';
 		}
 		$this->plugin_name = 'takamoa-papi-integration';
 		$this->load_dependencies();

--- a/takamoa-papi-integration.php
+++ b/takamoa-papi-integration.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Takamoa Papi Integration
  * Plugin URI:        https://nexa.takamoa.com/nos-realisations/
  * Description:       Easily generate and track payment links via Papi.mg directly from your WordPress site. Supports MVOLA, Orange Money, Airtel Money, and BRED. Includes real-time status tracking and customizable forms.
- * Version:           0.0.6
+ * Version:           0.0.7
  * Author:            Nexa by Takamoa
  * Author URI:        https://nexa.takamoa.com/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 0.0.1 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAKAMOA_PAPI_INTEGRATION_VERSION', '0.0.6' );
+define( 'TAKAMOA_PAPI_INTEGRATION_VERSION', '0.0.7' );
 /**
  * The code that runs during plugin activation.
  * This action is documented in includes/class-takamoa-papi-integration-activator.php


### PR DESCRIPTION
## Summary
- bump plugin header and constant to version 0.0.7
- synchronize internal fallback version with new release

## Testing
- `php -l takamoa-papi-integration.php`
- `php -l includes/class-takamoa-papi-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5d61121f4832e84d229bb6d7ce80f