### PR TITLE
Track ticket update timestamps

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -419,6 +419,7 @@ class Takamoa_Papi_Integration_Admin
 												<th>Description</th>
 												<th>QR Code</th>
 												<th>Date création</th>
+												<th>Date mise à jour</th>
 												<th>Status</th>
 												<th>Dernière notification</th>
 										</tr>
@@ -430,6 +431,7 @@ class Takamoa_Papi_Integration_Admin
 												<td><?= esc_html($row->description ?: '—') ?></td>
 												<td><?= $row->qrcode_link ? '<a href="' . esc_url($row->qrcode_link) . '" target="_blank">Voir</a>' : '—'; ?></td>
 												<td><?= esc_html($row->created_at) ?></td>
+												<td><?= esc_html($row->updated_at ?: '—') ?></td>
 												<td><?= esc_html($row->status) ?></td>
 												<td><?= esc_html($row->last_notification ?: '—') ?></td>
 										</tr>

--- a/includes/class-takamoa-papi-integration-activator.php
+++ b/includes/class-takamoa-papi-integration-activator.php
@@ -77,8 +77,9 @@ class Takamoa_Papi_Integration_Activator
 						reference VARCHAR(100) NOT NULL,
 						qrcode_link TEXT,
 						description TEXT,
-						created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-						status VARCHAR(50) DEFAULT 'PENDING',
+				created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+				updated_at DATE DEFAULT NULL,
+				status VARCHAR(50) DEFAULT 'PENDING',
 						last_notification DATETIME NULL,
 						UNIQUE KEY unique_reference (reference)
 				) $charset_collate;";

--- a/includes/class-takamoa-papi-integration-functions.php
+++ b/includes/class-takamoa-papi-integration-functions.php
@@ -501,6 +501,7 @@ class Takamoa_Papi_Integration_Functions
 				[
 					'qrcode_link' => $url,
 					'status' => 'GENERATED',
+					'updated_at' => current_time('mysql'),
 				],
 				['id' => $ticket->id],
 			);
@@ -510,6 +511,7 @@ class Takamoa_Papi_Integration_Functions
 				'qrcode_link' => $url,
 				'status' => 'GENERATED',
 				'created_at' => current_time('mysql'),
+				'updated_at' => current_time('mysql'),
 			]);
 		}
 


### PR DESCRIPTION
## Summary
- add `updated_at` field to `takamoa_papi_tickets` table
- update ticket generation to refresh `updated_at`
- show last update date in Tickets admin page

## Testing
- `php -l includes/class-takamoa-papi-integration-activator.php`
- `php -l includes/class-takamoa-papi-integration-functions.php`
- `php -l admin/class-takamoa-papi-integration-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5da4c1a64832ebf156980daf67a34