### PR TITLE
feat: add ticket email action

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -420,22 +420,33 @@ class Takamoa_Papi_Integration_Admin
 												<th>QR Code</th>
 												<th>Date création</th>
 												<th>Date mise à jour</th>
-												<th>Status</th>
-												<th>Dernière notification</th>
-										</tr>
-								</thead>
-								<tbody>
-							<?php foreach ($results as $row) : ?>
-										<tr>
-												<td><?= esc_html($row->reference) ?></td>
-												<td><?= esc_html($row->description ?: '—') ?></td>
-												<td><?= $row->qrcode_link ? '<a href="' . esc_url($row->qrcode_link) . '" target="_blank">Voir</a>' : '—'; ?></td>
-												<td><?= esc_html($row->created_at) ?></td>
-												<td><?= esc_html($row->updated_at ?: '—') ?></td>
-												<td><?= esc_html($row->status) ?></td>
-												<td><?= esc_html($row->last_notification ?: '—') ?></td>
-										</tr>
-							<?php endforeach; ?>
+	<th>Status</th>
+	<th>Dernière notification</th>
+	<th>Action</th>
+											</tr>
+									</thead>
+									<tbody>
+	<?php foreach ($results as $row) : ?>
+	<tr data-reference="<?= esc_attr($row->reference) ?>">
+	<td><?= esc_html($row->reference) ?></td>
+	<td><?= esc_html($row->description ?: '—') ?></td>
+	<td><?= $row->qrcode_link ? '<a href="' . esc_url($row->qrcode_link) . '" target="_blank">Voir</a>' : '—'; ?></td>
+	<td><?= esc_html($row->created_at) ?></td>
+	<td><?= esc_html($row->updated_at ?: '—') ?></td>
+	<td><?= esc_html($row->status) ?></td>
+	<td><?= esc_html($row->last_notification ?: '—') ?></td>
+	<td>
+	<div class="btn-group">
+		<button type="button" class="btn btn-sm btn-secondary dropdown-toggle takamoa-action-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+		<i class="fa fa-cog"></i>
+		</button>
+		<ul class="dropdown-menu">
+		<li><button type="button" class="dropdown-item takamoa-send-ticket-email">Envoyer le billet par email</button></li>
+		</ul>
+		</div>
+		</td>
+	</tr>
+	<?php endforeach; ?>
 								</tbody>
 						</table>
 				</div>

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -195,6 +195,31 @@ if ($('#takamoa-tickets-table').length) {
 	twrapper
 	.find('.dataTables_length label, .dataTables_filter label')
 	.addClass('d-flex align-items-center gap-2 mb-0');
+	
+	$('#takamoa-tickets-table').on('click', '.takamoa-send-ticket-email', function (e) {
+	e.stopPropagation();
+	var btn = $(this);
+	var row = btn.closest('tr');
+	btn.prop('disabled', true);
+	$.post(takamoaAjax.ajaxurl, {
+	action: 'takamoa_send_ticket_email',
+	nonce: takamoaAjax.nonce,
+	reference: row.data('reference'),
+	})
+		.done(function (res) {
+	alert(
+	res.data && res.data.message
+	? res.data.message
+	: 'Billet envoyé'
+	);
+	})
+	.fail(function () {
+	alert("Erreur lors de l'envoi du billet");
+	})
+	.always(function () {
+	btn.prop('disabled', false);
+	});
+	});
 }
 
 if ($('#select_design_image').length) {

--- a/includes/class-takamoa-papi-integration.php
+++ b/includes/class-takamoa-papi-integration.php
@@ -174,12 +174,13 @@ class Takamoa_Papi_Integration {
 		$this->loader->add_action('admin_menu', $plugin_admin, 'add_menu');
 		$this->loader->add_action('admin_init', $plugin_admin, 'register_settings');
 		$this->loader->add_action('admin_post_takamoa_save_design', $plugin_admin, 'handle_save_design');
-		$this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
-		$this->loader->add_action('wp_ajax_takamoa_ticket_exists', $this->functions, 'handle_ticket_exists_ajax');
-		$this->loader->add_action('wp_ajax_takamoa_generate_ticket', $this->functions, 'handle_generate_ticket_ajax');
-		$this->loader->add_action('wp_ajax_takamoa_scan_ticket', $this->functions, 'handle_scan_ticket_ajax'); // @since 0.0.5
-		$this->loader->add_action('wp_ajax_takamoa_validate_ticket', $this->functions, 'handle_validate_ticket_ajax'); // @since 0.0.6
-	}
+	$this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
+	$this->loader->add_action('wp_ajax_takamoa_ticket_exists', $this->functions, 'handle_ticket_exists_ajax');
+	$this->loader->add_action('wp_ajax_takamoa_generate_ticket', $this->functions, 'handle_generate_ticket_ajax');
+	$this->loader->add_action('wp_ajax_takamoa_scan_ticket', $this->functions, 'handle_scan_ticket_ajax'); // @since 0.0.5
+	$this->loader->add_action('wp_ajax_takamoa_validate_ticket', $this->functions, 'handle_validate_ticket_ajax'); // @since 0.0.6
+	$this->loader->add_action('wp_ajax_takamoa_send_ticket_email', $this->functions, 'handle_send_ticket_email_ajax');
+}
 
 	/**
 	* Register all of the hooks related to the public-facing functionality


### PR DESCRIPTION
## Summary
- add action column to ticket list with dropdown button
- enable email delivery of tickets via AJAX
- wire up backend and client handlers for ticket email action

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l includes/class-takamoa-papi-integration-functions.php`
- `php -l includes/class-takamoa-papi-integration.php`
- `node --check admin/js/takamoa-papi-integration-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5df40d844832e9556e47b34e79d96