### PR TITLE
Add title field to ticket designs

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -466,14 +466,18 @@ class Takamoa_Papi_Integration_Admin
 		?>
 				<div class="wrap container-fluid">
 						<h1>Designs de billets</h1>
-						<form id="takamoa-add-design" method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
-								<?php wp_nonce_field('takamoa_save_design'); ?>
-								<input type="hidden" name="action" value="takamoa_save_design">
-								<p>
-										<label for="design_image">Image du billet</label><br>
-										<input type="text" id="design_image" name="design_image" class="form-control" />
-										<button type="button" class="button btn btn-outline-secondary" id="select_design_image">Choisir une image</button>
-								</p>
+                                                <form id="takamoa-add-design" method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
+                                                                <?php wp_nonce_field('takamoa_save_design'); ?>
+                                                                <input type="hidden" name="action" value="takamoa_save_design">
+                                                                <p>
+                                                                                <label for="design_title">Titre du design</label><br>
+                                                                                <input type="text" id="design_title" name="design_title" class="form-control" />
+                                                                </p>
+                                                                <p>
+                                                                                <label for="design_image">Image du billet</label><br>
+                                                                                <input type="text" id="design_image" name="design_image" class="form-control" />
+                                                                                <button type="button" class="button btn btn-outline-secondary" id="select_design_image">Choisir une image</button>
+                                                                </p>
 								<p>
 										<label>Largeur (px)</label>
 										<input type="number" id="ticket_width" name="ticket_width" class="form-control" min="1">
@@ -493,28 +497,30 @@ class Takamoa_Papi_Integration_Admin
 						<hr>
 						<table class="widefat striped table table-striped align-middle">
 								<thead>
-										<tr>
-												<th>ID</th>
-												<th>Image</th>
-												<th>Billet (px)</th>
-												<th>Taille QR</th>
-												<th>Position QR</th>
-												<th>Date</th>
-										</tr>
-								</thead>
-								<tbody>
-							<?php foreach ($designs as $d) : ?>
-										<tr>
-												<td><?= esc_html($d->id) ?></td>
-												<td><?= $d->image_url ? '<img src="' . esc_url($d->image_url) . '" style="max-width:150px;height:auto;" />' : '—'; ?></td>
-												<td><?= esc_html($d->ticket_width . '×' . $d->ticket_height) ?></td>
-												<td><?= esc_html($d->qrcode_size) ?></td>
-												<td><?= esc_html($d->qrcode_left . ',' . $d->qrcode_top) ?></td>
-												<td><?= esc_html($d->created_at) ?></td>
-										</tr>
-							<?php endforeach; ?>
-								</tbody>
-						</table>
+                                                                                <tr>
+                                                                                                <th>ID</th>
+                                                                                                <th>Titre</th>
+                                                                                                <th>Image</th>
+                                                                                                <th>Billet (px)</th>
+                                                                                                <th>Taille QR</th>
+                                                                                                <th>Position QR</th>
+                                                                                                <th>Date</th>
+                                                                                </tr>
+                                                                </thead>
+                                                                <tbody>
+                                                        <?php foreach ($designs as $d) : ?>
+                                                                                <tr>
+                                                                                                <td><?= esc_html($d->id) ?></td>
+                                                                                                <td><?= esc_html($d->title) ?></td>
+                                                                                                <td><?= $d->image_url ? '<img src="' . esc_url($d->image_url) . '" style="max-width:150px;height:auto;" />' : '—'; ?></td>
+                                                                                                <td><?= esc_html($d->ticket_width . '×' . $d->ticket_height) ?></td>
+                                                                                                <td><?= esc_html($d->qrcode_size) ?></td>
+                                                                                                <td><?= esc_html($d->qrcode_left . ',' . $d->qrcode_top) ?></td>
+                                                                                                <td><?= esc_html($d->created_at) ?></td>
+                                                                                </tr>
+                                                        <?php endforeach; ?>
+                                                                </tbody>
+                                                </table>
 				</div>
 				<?php
 	}
@@ -567,17 +573,18 @@ class Takamoa_Papi_Integration_Admin
 	{
 			check_admin_referer('takamoa_save_design');
 
-			$image        = esc_url_raw($_POST['design_image'] ?? '');
-			$width        = intval($_POST['ticket_width'] ?? 0);
-			$height       = intval($_POST['ticket_height'] ?? 0);
-			$qrsize       = intval($_POST['qrcode_size'] ?? 0);
-			$qtop         = intval($_POST['qrcode_top'] ?? 0);
-			$qleft        = intval($_POST['qrcode_left'] ?? 0);
+                        $title        = sanitize_text_field($_POST['design_title'] ?? '');
+                        $image        = esc_url_raw($_POST['design_image'] ?? '');
+                        $width        = intval($_POST['ticket_width'] ?? 0);
+                        $height       = intval($_POST['ticket_height'] ?? 0);
+                        $qrsize       = intval($_POST['qrcode_size'] ?? 0);
+                        $qtop         = intval($_POST['qrcode_top'] ?? 0);
+                        $qleft        = intval($_POST['qrcode_left'] ?? 0);
 
-			if (!$image || !$width || !$height || !$qrsize) {
-				wp_redirect(add_query_arg('error', 'missing', wp_get_referer()));
-				exit;
-			}
+                        if (!$title || !$image || !$width || !$height || !$qrsize) {
+                                wp_redirect(add_query_arg('error', 'missing', wp_get_referer()));
+                                exit;
+                        }
 
 			$attachment_id = attachment_url_to_postid($image);
 			if ($attachment_id) {
@@ -590,15 +597,16 @@ class Takamoa_Papi_Integration_Admin
 
 			global $wpdb;
 			$table = $wpdb->prefix . 'takamoa_papi_designs';
-			$wpdb->insert($table, [
-				'image_url'    => $image,
-				'ticket_width' => $width,
-				'ticket_height'=> $height,
-				'qrcode_size'  => $qrsize,
-				'qrcode_top'   => $qtop,
-				'qrcode_left'  => $qleft,
-				'created_at'   => current_time('mysql')
-			]);
+                        $wpdb->insert($table, [
+                                'title'        => $title,
+                                'image_url'    => $image,
+                                'ticket_width' => $width,
+                                'ticket_height'=> $height,
+                                'qrcode_size'  => $qrsize,
+                                'qrcode_top'   => $qtop,
+                                'qrcode_left'  => $qleft,
+                                'created_at'   => current_time('mysql')
+                        ]);
 
 			wp_redirect(add_query_arg('success', '1', wp_get_referer()));
 			exit;

--- a/includes/class-takamoa-papi-integration-activator.php
+++ b/includes/class-takamoa-papi-integration-activator.php
@@ -90,16 +90,17 @@ class Takamoa_Papi_Integration_Activator
 			// @since 0.0.3
 			$designs_table = $wpdb->prefix . 'takamoa_papi_designs';
 
-			$sql_designs = "CREATE TABLE $designs_table (
-				id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-				image_url TEXT NOT NULL,
-				ticket_width INT NOT NULL,
-				ticket_height INT NOT NULL,
-				qrcode_size INT NOT NULL,
-				qrcode_top INT NOT NULL,
-				qrcode_left INT NOT NULL,
-				created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-			) $charset_collate;";
+                        $sql_designs = "CREATE TABLE $designs_table (
+                                id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                                title VARCHAR(255) NOT NULL,
+                                image_url TEXT NOT NULL,
+                                ticket_width INT NOT NULL,
+                                ticket_height INT NOT NULL,
+                                qrcode_size INT NOT NULL,
+                                qrcode_top INT NOT NULL,
+                                qrcode_left INT NOT NULL,
+                                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                        ) $charset_collate;";
 
 			dbDelta($sql_designs);
 


### PR DESCRIPTION
## Summary
- add `title` column to designs table to store a label for each design
- expose title field on design admin page and show in listings
- persist design title when saving

## Testing
- `php -l includes/class-takamoa-papi-integration-activator.php`
- `php -l admin/class-takamoa-papi-integration-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5e688ac00832e925a6ee6b55f2c17