### PR TITLE
Add ticket parameter to shortcode and persist design ID

### DIFF
--- a/public/class-takamoa-papi-integration-public.php
+++ b/public/class-takamoa-papi-integration-public.php
@@ -102,14 +102,18 @@ class Takamoa_Papi_Integration_Public {
 	 * Shortcode qui affiche le conteneur Vue.js
 	 */
 		public function render_vue_form_shortcode($atts) {
-				$atts = shortcode_atts([
-						'amount' => '',
-						'reference' => '',
-						'payment' => 'yes'
-				], $atts);
+                               $atts = shortcode_atts([
+                                               'amount' => '',
+                                               'reference' => '',
+                                               'payment' => 'yes',
+                                               'ticket' => '',
+                               ], $atts);
 
-				// Assure que le paramètre payment n'accepte que 'yes' ou 'no'
-				$atts['payment'] = in_array($atts['payment'], ['yes', 'no'], true) ? $atts['payment'] : 'yes';
+                               // Assure que le paramètre payment n'accepte que 'yes' ou 'no'
+                               $atts['payment'] = in_array($atts['payment'], ['yes', 'no'], true) ? $atts['payment'] : 'yes';
+
+                               // Assure que ticket est un entier valide
+                               $atts['ticket'] = is_numeric($atts['ticket']) ? intval($atts['ticket']) : '';
 	
 		$timestamp = time();
 	
@@ -128,12 +132,13 @@ class Takamoa_Papi_Integration_Public {
 	
 		ob_start();
 		?>
-				<div id="<?php echo esc_attr($uid); ?>"
-						 class="takamoa-papi-app"
-						 data-amount="<?php echo esc_attr($atts['amount']); ?>"
-						 data-reference="<?php echo esc_attr($atts['reference']); ?>"
-						 data-payment="<?php echo esc_attr($atts['payment']); ?>">
-				</div>
+                               <div id="<?php echo esc_attr($uid); ?>"
+                                                class="takamoa-papi-app"
+                                                data-amount="<?php echo esc_attr($atts['amount']); ?>"
+                                                data-reference="<?php echo esc_attr($atts['reference']); ?>"
+                                                data-payment="<?php echo esc_attr($atts['payment']); ?>"
+                                                data-ticket="<?php echo esc_attr($atts['ticket']); ?>">
+                               </div>
 		<?php
 		return ob_get_clean();
 	}

--- a/public/js/takamoa-papi-form.js
+++ b/public/js/takamoa-papi-form.js
@@ -4,9 +4,10 @@ document.querySelectorAll('.takamoa-papi-app').forEach((el) => {
 		data: {
 			clientFirstName: '',
 			clientLastName: '',
-			amount: el.dataset.amount || '',
-			reference: el.dataset.reference || '',
-			payment: el.dataset.payment === 'no' ? 'no' : 'yes',
+                        amount: el.dataset.amount || '',
+                        reference: el.dataset.reference || '',
+                        payment: el.dataset.payment === 'no' ? 'no' : 'yes',
+                        ticket: el.dataset.ticket || '',
 			payerEmail: '',
 			payerPhone: '',
 			description: '',
@@ -50,8 +51,9 @@ document.querySelectorAll('.takamoa-papi-app').forEach((el) => {
 					reference: this.reference,
 					payerEmail: this.payerEmail,
 					payerPhone: this.payerPhone,
-					description: this.description,
-				};
+                                        description: this.description,
+                                        design_id: this.ticket,
+                                };
 
 				if (this.provider) {
 					data.provider = this.provider;


### PR DESCRIPTION
## Summary
- allow `takamoa_papi_form` shortcode to accept a `ticket` parameter
- send ticket design ID through the frontend and save it in payments

## Testing
- `php -l public/class-takamoa-papi-integration-public.php`
- `php -l includes/class-takamoa-papi-integration-functions.php`
- `node --check public/js/takamoa-papi-form.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6c2baa4d0832e8a03c6eecfc3702e