### PR TITLE
Add button to regenerate Papi payment link

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -312,11 +312,12 @@ class Takamoa_Papi_Integration_Admin
 							<button type="button" class="btn btn-sm btn-secondary dropdown-toggle takamoa-action-toggle" data-bs-toggle="dropdown" aria-expanded="false">
 								<i class="fa fa-cog"></i>
 							</button>
-							<ul class="dropdown-menu">
-								<li><button type="button" class="dropdown-item takamoa-notify">Notifier</button></li>
-								<li><button type="button" class="dropdown-item takamoa-generate-ticket">Générer un billet</button></li>
-								<li><button type="button" class="dropdown-item takamoa-details">Détails</button></li>
-							</ul>
+                                                       <ul class="dropdown-menu">
+                                                               <li><button type="button" class="dropdown-item takamoa-notify">Notifier</button></li>
+                                                               <li><button type="button" class="dropdown-item takamoa-regenerate-link">Regénérer le lien de paiement</button></li>
+                                                               <li><button type="button" class="dropdown-item takamoa-generate-ticket">Générer un billet</button></li>
+                                                               <li><button type="button" class="dropdown-item takamoa-details">Détails</button></li>
+                                                       </ul>
 						</div>
 					</td>
 				</tr>

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -102,6 +102,46 @@ $('#takamoa-payments-table').on('click', '.takamoa-notify', function (e) {
 });
 });
 
+$('#takamoa-payments-table').on('click', '.takamoa-regenerate-link', function (e) {
+        e.stopPropagation();
+        var btn = $(this);
+        var row = btn.closest('tr');
+        btn.prop('disabled', true);
+        $.post(takamoaAjax.ajaxurl, {
+                action: 'takamoa_regenerate_payment_link',
+                nonce: takamoaAjax.nonce,
+                reference: row.data('reference'),
+        })
+                .done(function (res) {
+                        if (res.success && res.data) {
+                                alert('Lien régénéré');
+                                row.data('paymentLink', res.data.payment_link).attr('data-payment-link', res.data.payment_link);
+                                row.data('linkCreation', res.data.link_creation).attr('data-link-creation', res.data.link_creation);
+                                row.data('linkExpiration', res.data.link_expiration).attr('data-link-expiration', res.data.link_expiration);
+                                row.data('notificationToken', res.data.notification_token).attr('data-notification-token', res.data.notification_token);
+                                row.data('rawRequest', res.data.raw_request).attr('data-raw-request', res.data.raw_request);
+                                row.data('rawResponse', res.data.raw_response).attr('data-raw-response', res.data.raw_response);
+                                row.data('updatedAt', res.data.updated_at).attr('data-updated-at', res.data.updated_at);
+                                row.data('status', res.data.status).attr('data-status', res.data.status);
+                                row.data('method', res.data.payment_method).attr('data-method', res.data.payment_method);
+                                row.find('td').eq(5).text(res.data.status);
+                                row.find('td').eq(6).text(res.data.payment_method);
+                        } else {
+                                alert(
+                                        res.data && res.data.message
+                                                ? res.data.message
+                                                : 'Erreur lors de la régénération'
+                                );
+                        }
+                })
+                .fail(function () {
+                        alert('Erreur lors de la régénération');
+                })
+                .always(function () {
+                        btn.prop('disabled', false);
+                });
+});
+
 var currentRef = '';
 $('#takamoa-payments-table').on('click', '.takamoa-generate-ticket', function (e) {
 	e.stopPropagation();

--- a/includes/class-takamoa-papi-integration.php
+++ b/includes/class-takamoa-papi-integration.php
@@ -173,9 +173,10 @@ class Takamoa_Papi_Integration {
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 		$this->loader->add_action('admin_menu', $plugin_admin, 'add_menu');
 		$this->loader->add_action('admin_init', $plugin_admin, 'register_settings');
-		$this->loader->add_action('admin_post_takamoa_save_design', $plugin_admin, 'handle_save_design');
-	$this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
-	$this->loader->add_action('wp_ajax_takamoa_ticket_exists', $this->functions, 'handle_ticket_exists_ajax');
+        $this->loader->add_action('admin_post_takamoa_save_design', $plugin_admin, 'handle_save_design');
+        $this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
+        $this->loader->add_action('wp_ajax_takamoa_regenerate_payment_link', $this->functions, 'handle_regenerate_payment_link_ajax');
+        $this->loader->add_action('wp_ajax_takamoa_ticket_exists', $this->functions, 'handle_ticket_exists_ajax');
 	$this->loader->add_action('wp_ajax_takamoa_generate_ticket', $this->functions, 'handle_generate_ticket_ajax');
 	$this->loader->add_action('wp_ajax_takamoa_scan_ticket', $this->functions, 'handle_scan_ticket_ajax'); // @since 0.0.5
 	$this->loader->add_action('wp_ajax_takamoa_validate_ticket', $this->functions, 'handle_validate_ticket_ajax'); // @since 0.0.6


### PR DESCRIPTION
## Summary
- add “Regénérer le lien de paiement” action on payments list
- implement AJAX handler to regenerate Papi link and update record
- wire up JavaScript to refresh row data after regeneration

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l includes/class-takamoa-papi-integration-functions.php`
- `php -l includes/class-takamoa-papi-integration.php`
- `node --check admin/js/takamoa-papi-integration-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6c6ff069c832eb59b56ebd90d763a