### PR TITLE
Fix payment link regeneration in admin page

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -314,12 +314,12 @@ class Takamoa_Papi_Integration_Admin
 							</button>
                                                        <ul class="dropdown-menu">
                                                                <li><button type="button" class="dropdown-item takamoa-notify">Notifier</button></li>
-                                                               <li><button type="button" class="dropdown-item takamoa-regenerate-link">Regénérer le lien de paiement</button></li>
+                                                               <li><button type="button" class="dropdown-item takamoa-regenerate-link" data-reference="<?= esc_attr($row->reference) ?>">Regénérer le lien de paiement</button></li>
                                                                <li><button type="button" class="dropdown-item takamoa-generate-ticket">Générer un billet</button></li>
                                                                <li><button type="button" class="dropdown-item takamoa-details">Détails</button></li>
                                                        </ul>
-						</div>
-					</td>
+                                               </div>
+                                       </td>
 				</tr>
 			<?php endforeach; ?>
 				</tbody>

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -103,14 +103,19 @@ $('#takamoa-payments-table').on('click', '.takamoa-notify', function (e) {
 });
 
 $('#takamoa-payments-table').on('click', '.takamoa-regenerate-link', function (e) {
+        e.preventDefault();
         e.stopPropagation();
         var btn = $(this);
         var row = btn.closest('tr');
+        var reference = btn.data('reference') || (row.length ? row.data('reference') : '');
+        if (!reference) {
+                return;
+        }
         btn.prop('disabled', true);
         $.post(takamoaAjax.ajaxurl, {
                 action: 'takamoa_regenerate_payment_link',
                 nonce: takamoaAjax.nonce,
-                reference: row.data('reference'),
+                reference: reference,
         })
                 .done(function (res) {
                         if (res.success && res.data) {


### PR DESCRIPTION
## Summary
- ensure the Regenerate link button carries its payment reference
- guard click handler with a reference fallback and prevent default actions

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6d3f5de54832e9c8e9dca7ad218f5