### PR TITLE
feat: add default ticket design selection

### DIFF
--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -289,6 +289,29 @@ if ($('#select_design_image').length) {
 		frame.open();
 	});
 }
+
+if ($('.takamoa-set-default').length) {
+        $('.takamoa-set-default').on('click', function () {
+                var btn = $(this);
+                var id = btn.data('id');
+                $.post(takamoaAjax.ajaxurl, {
+                        action: 'takamoa_set_default_design',
+                        nonce: takamoaAjax.nonce,
+                        design_id: id,
+                })
+                        .done(function (res) {
+                                if (res.success) {
+                                        $('.takamoa-set-default i').removeClass('fa-star text-warning').addClass('fa-star-o');
+                                        btn.find('i').removeClass('fa-star-o').addClass('fa-star text-warning');
+                                } else {
+                                        alert(res.data && res.data.message ? res.data.message : 'Erreur lors de la mise à jour');
+                                }
+                        })
+                        .fail(function () {
+                                alert('Erreur lors de la mise à jour');
+                        });
+        });
+}
 if ($('#qr-reader').length) {
 	// QR code scanning feature @since 0.0.5
 	var scanResult = $('#scan-result');

--- a/includes/class-takamoa-papi-integration-activator.php
+++ b/includes/class-takamoa-papi-integration-activator.php
@@ -141,5 +141,6 @@ class Takamoa_Papi_Integration_Activator
 
         add_option('takamoa_papi_test_mode', false);
         add_option('takamoa_papi_test_reason', '');
+        add_option('takamoa_papi_default_design', 0);
     }
 }

--- a/includes/class-takamoa-papi-integration-functions.php
+++ b/includes/class-takamoa-papi-integration-functions.php
@@ -349,8 +349,8 @@ wp_mail($email, $subject, $message, $headers);
                 $description = sanitize_text_field($_POST['description'] ?? '');
                 $provider = sanitize_text_field($_POST['provider'] ?? '');
                 $design_id = intval($_POST['design_id'] ?? 0);
+                $designs_table = $wpdb->prefix . 'takamoa_papi_designs';
                 if ($design_id > 0) {
-                        $designs_table = $wpdb->prefix . 'takamoa_papi_designs';
                         $exists = $wpdb->get_var(
                                 $wpdb->prepare(
                                         'SELECT id FROM ' . $designs_table . ' WHERE id = %d',
@@ -359,7 +359,18 @@ wp_mail($email, $subject, $message, $headers);
                         );
                         $design_id = $exists ? $design_id : null;
                 } else {
-                        $design_id = null;
+                        $default_design = intval(get_option('takamoa_papi_default_design'));
+                        if ($default_design > 0) {
+                                $exists = $wpdb->get_var(
+                                        $wpdb->prepare(
+                                                'SELECT id FROM ' . $designs_table . ' WHERE id = %d',
+                                                $default_design,
+                                        ),
+                                );
+                                $design_id = $exists ? $default_design : null;
+                        } else {
+                                $design_id = null;
+                        }
                 }
 
 		if ($amount < 300 || !$clientName || !$reference) {
@@ -684,6 +695,10 @@ wp_mail($email, $subject, $message, $headers);
 
                 $reference = sanitize_text_field($_POST['reference'] ?? '');
                 $design_id = intval($_POST['design_id'] ?? 0);
+                if (!$design_id) {
+                        $default_design = intval(get_option('takamoa_papi_default_design'));
+                        $design_id = $default_design;
+                }
                 if (!$reference || !$design_id) {
                         wp_send_json_error(['message' => 'Données manquantes.']);
                 }

--- a/includes/class-takamoa-papi-integration.php
+++ b/includes/class-takamoa-papi-integration.php
@@ -177,10 +177,11 @@ class Takamoa_Papi_Integration {
         $this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
         $this->loader->add_action('wp_ajax_takamoa_regenerate_payment_link', $this->functions, 'handle_regenerate_payment_link_ajax');
         $this->loader->add_action('wp_ajax_takamoa_ticket_exists', $this->functions, 'handle_ticket_exists_ajax');
-	$this->loader->add_action('wp_ajax_takamoa_generate_ticket', $this->functions, 'handle_generate_ticket_ajax');
-	$this->loader->add_action('wp_ajax_takamoa_scan_ticket', $this->functions, 'handle_scan_ticket_ajax'); // @since 0.0.5
-	$this->loader->add_action('wp_ajax_takamoa_validate_ticket', $this->functions, 'handle_validate_ticket_ajax'); // @since 0.0.6
-	$this->loader->add_action('wp_ajax_takamoa_send_ticket_email', $this->functions, 'handle_send_ticket_email_ajax');
+        $this->loader->add_action('wp_ajax_takamoa_generate_ticket', $this->functions, 'handle_generate_ticket_ajax');
+        $this->loader->add_action('wp_ajax_takamoa_scan_ticket', $this->functions, 'handle_scan_ticket_ajax'); // @since 0.0.5
+        $this->loader->add_action('wp_ajax_takamoa_validate_ticket', $this->functions, 'handle_validate_ticket_ajax'); // @since 0.0.6
+        $this->loader->add_action('wp_ajax_takamoa_send_ticket_email', $this->functions, 'handle_send_ticket_email_ajax');
+        $this->loader->add_action('wp_ajax_takamoa_set_default_design', $plugin_admin, 'handle_set_default_design_ajax');
 }
 
 	/**

--- a/public/class-takamoa-papi-integration-public.php
+++ b/public/class-takamoa-papi-integration-public.php
@@ -109,11 +109,16 @@ class Takamoa_Papi_Integration_Public {
                                                'ticket' => '',
                                ], $atts);
 
+                               $default_design = intval(get_option('takamoa_papi_default_design'));
+
                                // Assure que le paramètre payment n'accepte que 'yes' ou 'no'
                                $atts['payment'] = in_array($atts['payment'], ['yes', 'no'], true) ? $atts['payment'] : 'yes';
 
                                // Assure que ticket est un entier valide
                                $atts['ticket'] = is_numeric($atts['ticket']) ? intval($atts['ticket']) : '';
+                               if ($atts['ticket'] === '' && $default_design) {
+                                               $atts['ticket'] = $default_design;
+                               }
 	
 		$timestamp = time();
 	


### PR DESCRIPTION
## Summary
- allow admins to mark a ticket design as the default and store it in options
- auto-select default design when generating tickets and on public forms
- support changing default design via AJAX with a star toggle on design list

## Testing
- `php -l includes/class-takamoa-papi-integration-activator.php`
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l includes/class-takamoa-papi-integration.php`
- `php -l public/class-takamoa-papi-integration-public.php`
- `php -l includes/class-takamoa-papi-integration-functions.php`

------
https://chatgpt.com/codex/tasks/task_e_68a6e3b59cfc832e8e340398a176597b