### PR TITLE
Add default design fallback for ticket generation

### DIFF
--- a/includes/class-takamoa-papi-integration-functions.php
+++ b/includes/class-takamoa-papi-integration-functions.php
@@ -322,8 +322,11 @@ wp_mail($email, $subject, $message, $headers);
                                 $payment->client_name,
                         );
 
-                        if (!empty($payment->design_id)) {
-                                $url = $this->generate_ticket_pdf($payment->reference, (int) $payment->design_id);
+                        $default_design = intval(get_option('takamoa_papi_default_design'));
+                        $design_id = !empty($payment->design_id) ? (int) $payment->design_id : $default_design;
+
+                        if (!empty($design_id)) {
+                                $url = $this->generate_ticket_pdf($payment->reference, $design_id);
                                 if ($url) {
                                         $this->send_ticket_email_by_reference($payment->reference);
                                 }


### PR DESCRIPTION
## Summary
- use default ticket design when payment does not have a custom design

## Testing
- `php -l includes/class-takamoa-papi-integration-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6e9a6f1b0832ea201d59c1725278d