### PR TITLE
Allow design deletion with confirmation

### DIFF
--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -312,6 +312,14 @@ if ($('.takamoa-set-default').length) {
                         });
         });
 }
+
+if ($('.takamoa-delete-design').length) {
+        $('.takamoa-delete-design').on('click', function (e) {
+                if (!confirm('Supprimer ce design ?')) {
+                        e.preventDefault();
+                }
+        });
+}
 if ($('#qr-reader').length) {
 	// QR code scanning feature @since 0.0.5
 	var scanResult = $('#scan-result');

--- a/includes/class-takamoa-papi-integration.php
+++ b/includes/class-takamoa-papi-integration.php
@@ -174,6 +174,7 @@ class Takamoa_Papi_Integration {
 		$this->loader->add_action('admin_menu', $plugin_admin, 'add_menu');
 		$this->loader->add_action('admin_init', $plugin_admin, 'register_settings');
         $this->loader->add_action('admin_post_takamoa_save_design', $plugin_admin, 'handle_save_design');
+        $this->loader->add_action('admin_post_takamoa_delete_design', $plugin_admin, 'handle_delete_design');
         $this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
         $this->loader->add_action('wp_ajax_takamoa_regenerate_payment_link', $this->functions, 'handle_regenerate_payment_link_ajax');
         $this->loader->add_action('wp_ajax_takamoa_ticket_exists', $this->functions, 'handle_ticket_exists_ajax');


### PR DESCRIPTION
## Summary
- enable deletion of ticket designs via new action column
- add server handler to remove designs and clear default when removed
- hook delete handler into admin post and confirm deletion in JS

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l includes/class-takamoa-papi-integration.php`
- `node --check admin/js/takamoa-papi-integration-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6f6a1083c832e9f97df6cfd4cef10