### PR TITLE
Apply custom header design to admin pages

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -283,37 +283,44 @@ class Takamoa_Papi_Integration_Admin
        */
        public function display_scanner_page()
        {
-                        ?>
-                        <style>
-			#wpadminbar,
-			#adminmenumain,
-			#adminmenuback,
-			#adminmenuwrap {
-				display: none;
-			}
-			.notice {
-					display: none;
-			}
-			#wpcontent,
-			#wpfooter {
-				margin-left: 0;
-			}
-			#takamoa-scanner-home {
-				position: fixed;
-				top: 20px;
-				left: 20px;
-				z-index: 999;
-			}
-                        </style>
-                        <div class="wrap text-center">
-                                        <a href="<?= esc_url(admin_url()); ?>" class="button button-secondary" id="takamoa-scanner-home">Home</a>
-                                        <h1>Scanner billets</h1>
-					<div id="qr-reader"></div>
-					<div id="scan-result" class="mt-3"></div>
-					<button id="rescan-btn" class="button button-primary mt-3">Re-scan</button>
-				</div>
+               ?>
+               <style>
+               #wpadminbar,
+               #adminmenumain,
+               #adminmenuback,
+               #adminmenuwrap {
+                       display: none;
+               }
+               .notice {
+                               display: none;
+               }
+               #wpcontent,
+               #wpfooter {
+                       margin-left: 0;
+               }
+               #takamoa-scanner-home {
+                       position: fixed;
+                       top: 20px;
+                       left: 20px;
+                       z-index: 999;
+               }
+               .tk-header{display:flex;align-items:center;justify-content:center;gap:12px;margin-bottom:20px;}
+               .tk-title{font-size:18px;font-weight:700;letter-spacing:.2px;}
+               .tk-sub{color:#8892a6;font-size:13px}
+               </style>
+               <div class="wrap text-center">
+                               <a href="<?= esc_url(admin_url()); ?>" class="button button-secondary" id="takamoa-scanner-home">Home</a>
+                               <header class="tk-header">
+                                       <div>
+                                               <div class="tk-title"><?php echo esc_html(get_admin_page_title()); ?></div>
+                                       </div>
+                               </header>
+                               <div id="qr-reader"></div>
+                               <div id="scan-result" class="mt-3"></div>
+                               <button id="rescan-btn" class="button button-primary mt-3">Re-scan</button>
+                       </div>
 <?php
-}
+       }
 
 	/**
 	* Handle saving a ticket design.

--- a/admin/partials/designs-page.php
+++ b/admin/partials/designs-page.php
@@ -5,10 +5,9 @@
  * @since 0.0.3
  */
 ?>
-                               <div class="wrap container-fluid">
-                                               <h1>Designs de billets</h1>
-                                               <section class="tk-wrap">
-                                                               <style>
+<div class="wrap container-fluid">
+    <section class="tk-wrap">
+        <style>
                                                                        :root{
                                                                                --bg:#0b0d12;
                                                                                --card:#121723;
@@ -82,12 +81,12 @@
                                                                        .tk-btn[disabled]{opacity:.5;cursor:not-allowed;}
                                                                </style>
 
-                                                               <header class="tk-header">
-                                                                               <div>
-                                                                                               <div class="tk-title">Créer un design de billet</div>
-                                                                                               <div class="tk-sub">Définis l’image, les dimensions et place le QR code précisément avec l’aperçu en direct.</div>
-                                                                               </div>
-                                                               </header>
+        <header class="tk-header">
+            <div>
+                <div class="tk-title"><?php echo esc_html(get_admin_page_title()); ?></div>
+                <div class="tk-sub">Définis l’image, les dimensions et place le QR code précisément avec l’aperçu en direct.</div>
+            </div>
+        </header>
 
                                                                <div class="tk-grid">
                                                                                <div class="tk-card">

--- a/admin/partials/payments-page.php
+++ b/admin/partials/payments-page.php
@@ -6,7 +6,6 @@
  */
 ?>
 <div class="wrap container-fluid">
-    <h1>Historique des paiements</h1>
     <section class="tk-wrap">
         <style>
             :root{
@@ -25,6 +24,9 @@
                 --gap:16px;
             }
             .tk-wrap{font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;color:var(--text);background:var(--bg);padding:24px;border-radius:var(--radius);box-shadow:0 0 0 1px #0f1320,0 10px 30px rgba(0,0,0,.35);}
+            .tk-header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:20px;}
+            .tk-title{font-size:18px;font-weight:700;letter-spacing:.2px;}
+            .tk-sub{color:var(--muted);font-size:13px}
             .tk-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:20px;}
             .tk-table{width:100%;border-collapse:collapse;}
             .tk-table th,.tk-table td{padding:12px;text-align:left;border-bottom:1px solid var(--border);}
@@ -39,6 +41,12 @@
             .tk-btn.danger:hover{background:rgba(255,107,107,.1);}
             .tk-actions{display:flex;gap:8px;flex-wrap:wrap;}
         </style>
+        <header class="tk-header">
+            <div>
+                <div class="tk-title"><?php echo esc_html(get_admin_page_title()); ?></div>
+                <div class="tk-sub">Liste des paiements effectués via Papi.mg.</div>
+            </div>
+        </header>
         <div class="tk-card">
             <table id="takamoa-payments-table" class="tk-table">
                 <thead>

--- a/admin/partials/tickets-page.php
+++ b/admin/partials/tickets-page.php
@@ -6,7 +6,6 @@
  */
 ?>
 <div class="wrap container-fluid">
-    <h1>Billets</h1>
     <section class="tk-wrap">
         <style>
             :root{
@@ -25,6 +24,9 @@
                 --gap:16px;
             }
             .tk-wrap{font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;color:var(--text);background:var(--bg);padding:24px;border-radius:var(--radius);box-shadow:0 0 0 1px #0f1320,0 10px 30px rgba(0,0,0,.35);}
+            .tk-header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:20px;}
+            .tk-title{font-size:18px;font-weight:700;letter-spacing:.2px;}
+            .tk-sub{color:var(--muted);font-size:13px}
             .tk-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:20px;}
             .tk-table{width:100%;border-collapse:collapse;}
             .tk-table th,.tk-table td{padding:12px;text-align:left;border-bottom:1px solid var(--border);}
@@ -38,6 +40,12 @@
             .tk-btn.danger{border-color:var(--err);color:var(--err);}
             .tk-btn.danger:hover{background:rgba(255,107,107,.1);}
         </style>
+        <header class="tk-header">
+            <div>
+                <div class="tk-title"><?php echo esc_html(get_admin_page_title()); ?></div>
+                <div class="tk-sub">Liste des billets générés.</div>
+            </div>
+        </header>
         <div class="tk-card">
             <table id="takamoa-tickets-table" class="tk-table">
                 <thead>


### PR DESCRIPTION
## Summary
- Replace default page titles with custom `.tk-header` across admin pages
- Style scanner page and remove default `<h1>` headings

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l admin/partials/designs-page.php`
- `php -l admin/partials/payments-page.php`
- `php -l admin/partials/tickets-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68a72d1330d4832eb6cd1e43951ef3d9