### PR TITLE
feat: restyle payment modals

### DIFF
--- a/admin/css/takamoa-papi-integration-admin.css
+++ b/admin/css/takamoa-papi-integration-admin.css
@@ -62,34 +62,52 @@
 	cursor: default;
 }
 
-/* Payment modal styling */
-#paymentModal .modal-header {
-	background-color: #0073aa;
-	color: #fff;
+/* Unified modal styling */
+.tk-modal .modal-content {
+        background: var(--card);
+        border: 1px solid var(--border);
+        color: var(--text);
+        border-radius: var(--radius);
 }
 
-#paymentModal .modal-header .btn-close {
-	filter: invert(1);
+.tk-modal .modal-header,
+.tk-modal .modal-footer {
+        border-color: var(--border);
 }
 
-#paymentModal .table th {
-	width: 40%;
-	white-space: nowrap;
+.tk-modal .modal-header .btn-close {
+        filter: invert(1);
 }
 
-#paymentModal .table-responsive {
-	max-height: 70vh;
-	overflow-y: auto;
+.tk-modal .form-select {
+        background-color: var(--bg);
+        color: var(--text);
+        border: 1px solid var(--border);
 }
 
-#paymentModal .table td {
-	word-break: break-word;
+.tk-modal .form-select:focus {
+        border-color: var(--primary);
+        box-shadow: 0 0 0 1px var(--primary);
 }
 
-#paymentModal pre {
-	white-space: pre-wrap;
-	word-break: break-word;
-	font-size: 0.875rem;
+.tk-modal .tk-table th {
+        width: 40%;
+        white-space: nowrap;
+}
+
+.tk-modal .table-responsive {
+        max-height: 70vh;
+        overflow-y: auto;
+}
+
+.tk-modal .tk-table td {
+        word-break: break-word;
+}
+
+.tk-modal pre {
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-size: 0.875rem;
 }
 #qr-reader {
 	max-width: 400px;

--- a/admin/partials/payments-page.php
+++ b/admin/partials/payments-page.php
@@ -106,7 +106,7 @@
         </div>
     </section>
 
-    <div class="modal fade" id="paymentModal" tabindex="-1" aria-hidden="true">
+    <div class="modal fade tk-modal" id="paymentModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered modal-lg modal-fullscreen-sm-down">
             <div class="modal-content">
                 <div class="modal-header">
@@ -115,7 +115,7 @@
                 </div>
                 <div class="modal-body">
                     <div class="table-responsive">
-                        <table class="table table-striped">
+                        <table class="tk-table">
                             <tbody id="modal-basic-info">
                                 <tr><th>ID</th><td id="modal-id"></td></tr>
                                 <tr><th>Référence</th><td id="modal-reference"></td></tr>
@@ -150,14 +150,14 @@
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-outline-primary" id="toggle-more-info">Show more</button>
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
+                    <button type="button" class="tk-btn" id="toggle-more-info">Show more</button>
+                    <button type="button" class="tk-btn" data-bs-dismiss="modal">Fermer</button>
                 </div>
             </div>
         </div>
     </div>
 
-    <div class="modal fade" id="ticketModal" tabindex="-1" aria-hidden="true">
+    <div class="modal fade tk-modal" id="ticketModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered modal-lg modal-fullscreen-sm-down">
             <div class="modal-content">
                 <div class="modal-header">
@@ -174,8 +174,8 @@
                     </select>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
-                    <button type="button" id="generate-ticket-btn" class="btn btn-primary">Générer</button>
+                    <button type="button" class="tk-btn" data-bs-dismiss="modal">Fermer</button>
+                    <button type="button" id="generate-ticket-btn" class="tk-btn">Générer</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- unify payment and ticket modals with dark theme styling
- centralize modal visuals in admin CSS and use custom buttons/tables

## Testing
- `php -l admin/partials/payments-page.php`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a728ee9f7c832eb28ef913a7b3a826