### PR TITLE
Refactor payment modals for unified admin UI

### DIFF
--- a/admin/css/takamoa-papi-integration-admin.css
+++ b/admin/css/takamoa-papi-integration-admin.css
@@ -62,34 +62,86 @@
 	cursor: default;
 }
 
-/* Payment modal styling */
-#paymentModal .modal-header {
-	background-color: #0073aa;
-	color: #fff;
+/* Payment and ticket modals */
+.tk-modal {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.6);
+        display: none;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
 }
 
-#paymentModal .modal-header .btn-close {
-	filter: invert(1);
+.tk-modal.show {
+        display: flex;
 }
 
-#paymentModal .table th {
-	width: 40%;
-	white-space: nowrap;
+.tk-modal-content {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        max-width: 800px;
+        width: 100%;
+        max-height: 90vh;
+        display: flex;
+        flex-direction: column;
+        box-shadow: 0 0 0 1px #0f1320, 0 10px 30px rgba(0, 0, 0, 0.35);
 }
 
-#paymentModal .table-responsive {
-	max-height: 70vh;
-	overflow-y: auto;
+.tk-modal-header,
+.tk-modal-footer {
+        padding: 16px 20px;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
 }
 
-#paymentModal .table td {
-	word-break: break-word;
+.tk-modal-footer {
+        border-top: 1px solid var(--border);
+        border-bottom: 0;
+        justify-content: flex-end;
+        gap: 8px;
 }
 
-#paymentModal pre {
-	white-space: pre-wrap;
-	word-break: break-word;
-	font-size: 0.875rem;
+.tk-modal-body {
+        padding: 20px;
+        overflow-y: auto;
+}
+
+.tk-modal .tk-table th {
+        width: 40%;
+        white-space: nowrap;
+}
+
+.tk-modal pre {
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-size: 0.875rem;
+}
+
+.tk-close {
+        background: none;
+        border: none;
+        color: var(--text);
+        cursor: pointer;
+        font-size: 20px;
+        line-height: 1;
+}
+
+.tk-modal select {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        color: var(--text);
+        padding: 10px 14px;
+        border-radius: 12px;
+        width: 100%;
+}
+
+/* Utilities */
+.d-none {
+        display: none !important;
 }
 #qr-reader {
 	max-width: 400px;

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -4,7 +4,24 @@
 * @since 0.0.3
 */
 jQuery(document).ready(function ($) {
-	if ($('#takamoa-payments-table').length) {
+        function openModal(id) {
+                $('#' + id).addClass('show');
+        }
+        function closeModal(id) {
+                $('#' + id).removeClass('show');
+        }
+
+        $(document).on('click', '[data-close]', function () {
+                closeModal($(this).data('close'));
+        });
+
+        $('.tk-modal').on('click', function (e) {
+                if ($(e.target).is('.tk-modal')) {
+                        closeModal($(this).attr('id'));
+                }
+        });
+
+        if ($('#takamoa-payments-table').length) {
 		var table = $('#takamoa-payments-table').DataTable({
 			pageLength: 10,
 			lengthMenu: [5, 10, 25, 50],
@@ -51,9 +68,9 @@ jQuery(document).ready(function ($) {
 			$('#modal-payment-link').text(row.data('paymentLink') || '—');
 			$('#modal-currency').text(row.data('currency') || '—');
 			$('#modal-fee').text(row.data('fee') || '—');
-			$('#modal-notification-token').text(
-			row.data('notificationToken') || '—',
-		);
+                $('#modal-notification-token').text(
+                        row.data('notificationToken') || '—'
+                );
 		$('#modal-test-mode').text(row.data('isTestMode') ? 'Yes' : 'No');
 		$('#modal-test-reason').text(row.data('testReason') || '—');
 		$('#modal-raw-request').text(row.data('rawRequest') || '—');
@@ -64,16 +81,13 @@ jQuery(document).ready(function ($) {
 		$('#modal-extra-info').addClass('d-none');
 		$('#toggle-more-info').text('Show more');
 		
-		var modal = new bootstrap.Modal(
-		document.getElementById('paymentModal'),
-	);
-	modal.show();
+                openModal('paymentModal');
 });
 
 $('#toggle-more-info').on('click', function () {
 	$('#modal-extra-info').toggleClass('d-none');
-	$(this).text(
-	$('#modal-extra-info').hasClass('d-none') ? 'Show more' : 'Show less',
+        $(this).text(
+        $('#modal-extra-info').hasClass('d-none') ? 'Show more' : 'Show less'
 );
 });
 
@@ -151,8 +165,7 @@ var currentRef = '';
 $('#takamoa-payments-table').on('click', '.takamoa-generate-ticket', function (e) {
 	e.stopPropagation();
 	currentRef = $(this).closest('tr').data('reference');
-	var modal = new bootstrap.Modal(document.getElementById('ticketModal'));
-	modal.show();
+        openModal('ticketModal');
 });
 
 $('#generate-ticket-btn').on('click', function () {
@@ -189,12 +202,10 @@ $('#generate-ticket-btn').on('click', function () {
 			alert('Erreur lors de la génération');
 		})
 		.always(function () {
-			btn.prop('disabled', false);
-			bootstrap.Modal.getInstance(
-				document.getElementById('ticketModal'),
-			).hide();
-		});
-	}
+                        btn.prop('disabled', false);
+                        closeModal('ticketModal');
+                });
+        }
 
 	$.post(takamoaAjax.ajaxurl, {
 		action: 'takamoa_ticket_exists',

--- a/admin/partials/payments-page.php
+++ b/admin/partials/payments-page.php
@@ -114,77 +114,71 @@
         </div>
     </section>
 
-    <div class="modal fade" id="paymentModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered modal-lg modal-fullscreen-sm-down">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Détails du paiement</h5>
-                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <div class="table-responsive">
-                        <table class="table table-striped">
-                            <tbody id="modal-basic-info">
-                                <tr><th>ID</th><td id="modal-id"></td></tr>
-                                <tr><th>Référence</th><td id="modal-reference"></td></tr>
-                                <tr><th>Nom client</th><td id="modal-name"></td></tr>
-                                <tr><th>Email</th><td id="modal-email"></td></tr>
-                                <tr><th>Téléphone</th><td id="modal-phone"></td></tr>
-                                <tr><th>Montant</th><td id="modal-amount"></td></tr>
-                                <tr><th>Status</th><td id="modal-status"></td></tr>
-                                <tr><th>Méthode</th><td id="modal-method"></td></tr>
-                                <tr><th>Date</th><td id="modal-date"></td></tr>
-                                <tr><th>Description</th><td id="modal-description"></td></tr>
-                            </tbody>
-                            <tbody id="modal-extra-info" class="d-none">
-                                <tr><th>Provider</th><td id="modal-provider"></td></tr>
-                                <tr><th>Success URL</th><td id="modal-success-url"></td></tr>
-                                <tr><th>Failure URL</th><td id="modal-failure-url"></td></tr>
-                                <tr><th>Notification URL</th><td id="modal-notification-url"></td></tr>
-                                <tr><th>Link creation</th><td id="modal-link-creation"></td></tr>
-                                <tr><th>Link expiration</th><td id="modal-link-expiration"></td></tr>
-                                <tr><th>Payment link</th><td id="modal-payment-link"></td></tr>
-                                <tr><th>Currency</th><td id="modal-currency"></td></tr>
-                                <tr><th>Fee</th><td id="modal-fee"></td></tr>
-                                <tr><th>Notification token</th><td id="modal-notification-token"></td></tr>
-                                <tr><th>Test mode</th><td id="modal-test-mode"></td></tr>
-                                <tr><th>Test reason</th><td id="modal-test-reason"></td></tr>
-                                <tr><th>Raw request</th><td><pre id="modal-raw-request" class="mb-0"></pre></td></tr>
-                                <tr><th>Raw response</th><td><pre id="modal-raw-response" class="mb-0"></pre></td></tr>
-                                <tr><th>Raw notification</th><td><pre id="modal-raw-notification" class="mb-0"></pre></td></tr>
-                                <tr><th>Updated at</th><td id="modal-updated-at"></td></tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-outline-primary" id="toggle-more-info">Show more</button>
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
-                </div>
+    <div class="tk-modal" id="paymentModal" aria-hidden="true">
+        <div class="tk-modal-content tk-card">
+            <div class="tk-modal-header">
+                <h3 class="tk-title">Détails du paiement</h3>
+                <button type="button" class="tk-close" data-close="paymentModal">&times;</button>
+            </div>
+            <div class="tk-modal-body">
+                <table class="tk-table">
+                    <tbody id="modal-basic-info">
+                        <tr><th>ID</th><td id="modal-id"></td></tr>
+                        <tr><th>Référence</th><td id="modal-reference"></td></tr>
+                        <tr><th>Nom client</th><td id="modal-name"></td></tr>
+                        <tr><th>Email</th><td id="modal-email"></td></tr>
+                        <tr><th>Téléphone</th><td id="modal-phone"></td></tr>
+                        <tr><th>Montant</th><td id="modal-amount"></td></tr>
+                        <tr><th>Status</th><td id="modal-status"></td></tr>
+                        <tr><th>Méthode</th><td id="modal-method"></td></tr>
+                        <tr><th>Date</th><td id="modal-date"></td></tr>
+                        <tr><th>Description</th><td id="modal-description"></td></tr>
+                    </tbody>
+                    <tbody id="modal-extra-info" class="d-none">
+                        <tr><th>Provider</th><td id="modal-provider"></td></tr>
+                        <tr><th>Success URL</th><td id="modal-success-url"></td></tr>
+                        <tr><th>Failure URL</th><td id="modal-failure-url"></td></tr>
+                        <tr><th>Notification URL</th><td id="modal-notification-url"></td></tr>
+                        <tr><th>Link creation</th><td id="modal-link-creation"></td></tr>
+                        <tr><th>Link expiration</th><td id="modal-link-expiration"></td></tr>
+                        <tr><th>Payment link</th><td id="modal-payment-link"></td></tr>
+                        <tr><th>Currency</th><td id="modal-currency"></td></tr>
+                        <tr><th>Fee</th><td id="modal-fee"></td></tr>
+                        <tr><th>Notification token</th><td id="modal-notification-token"></td></tr>
+                        <tr><th>Test mode</th><td id="modal-test-mode"></td></tr>
+                        <tr><th>Test reason</th><td id="modal-test-reason"></td></tr>
+                        <tr><th>Raw request</th><td><pre id="modal-raw-request"></pre></td></tr>
+                        <tr><th>Raw response</th><td><pre id="modal-raw-response"></pre></td></tr>
+                        <tr><th>Raw notification</th><td><pre id="modal-raw-notification"></pre></td></tr>
+                        <tr><th>Updated at</th><td id="modal-updated-at"></td></tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="tk-modal-footer">
+                <button type="button" class="tk-btn" id="toggle-more-info">Show more</button>
+                <button type="button" class="tk-btn" data-close="paymentModal">Fermer</button>
             </div>
         </div>
     </div>
 
-    <div class="modal fade" id="ticketModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered modal-lg modal-fullscreen-sm-down">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Générer un billet</h5>
-                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                    <select id="ticket-design" class="form-select">
-                        <?php foreach ($designs as $d) : ?>
-                            <option value="<?= esc_attr($d->id) ?>" <?= selected($d->id, $default_design, false) ?>>
-                                <?= esc_html($d->title) ?><?= $d->id == $default_design ? ' (par défaut)' : '' ?>
-                            </option>
-                        <?php endforeach; ?>
-                    </select>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
-                    <button type="button" id="generate-ticket-btn" class="btn btn-primary">Générer</button>
-                </div>
+    <div class="tk-modal" id="ticketModal" aria-hidden="true">
+        <div class="tk-modal-content tk-card">
+            <div class="tk-modal-header">
+                <h3 class="tk-title">Générer un billet</h3>
+                <button type="button" class="tk-close" data-close="ticketModal">&times;</button>
+            </div>
+            <div class="tk-modal-body">
+                <select id="ticket-design">
+                    <?php foreach ($designs as $d) : ?>
+                        <option value="<?= esc_attr($d->id) ?>" <?= selected($d->id, $default_design, false) ?>>
+                            <?= esc_html($d->title) ?><?= $d->id == $default_design ? ' (par défaut)' : '' ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="tk-modal-footer">
+                <button type="button" class="tk-btn" data-close="ticketModal">Fermer</button>
+                <button type="button" id="generate-ticket-btn" class="tk-btn">Générer</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle payment and ticket modals with tk design
- add modal helpers and remove bootstrap dependencies
- style modals to match admin theme

## Testing
- `php -l admin/partials/payments-page.php`
- `node --check admin/js/takamoa-papi-integration-admin.js`
- `npm test` (fails: Could not read package.json)
- `composer test` (fails: Command "test" is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68a73156f310832e995991e3293a4bc8