### PR TITLE
Ensure modal text appears white

### DIFF
--- a/admin/partials/payments-page.php
+++ b/admin/partials/payments-page.php
@@ -40,6 +40,10 @@
             .tk-btn.danger{border-color:var(--err);color:var(--err);}
             .tk-btn.danger:hover{background:rgba(255,107,107,.1);}
             .tk-actions{display:flex;gap:8px;flex-wrap:wrap;}
+            .tk-modal,
+            .tk-modal .tk-btn,
+            .tk-modal .tk-close,
+            .tk-modal select{color:#fff;}
         </style>
         <header class="tk-header">
             <div>


### PR DESCRIPTION
## Summary
- Force white text color across modal content and controls for clear contrast.

## Testing
- `php -l admin/partials/payments-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68a733e06bf4832eb4a053dba5a9f923