### PR TITLE
Align scanner UI with existing design pages

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -283,43 +283,7 @@ class Takamoa_Papi_Integration_Admin
        */
        public function display_scanner_page()
        {
-               ?>
-               <style>
-               #wpadminbar,
-               #adminmenumain,
-               #adminmenuback,
-               #adminmenuwrap {
-                       display: none;
-               }
-               .notice {
-                               display: none;
-               }
-               #wpcontent,
-               #wpfooter {
-                       margin-left: 0;
-               }
-               #takamoa-scanner-home {
-                       position: fixed;
-                       top: 20px;
-                       left: 20px;
-                       z-index: 999;
-               }
-               .tk-header{display:flex;align-items:center;justify-content:center;gap:12px;margin-bottom:20px;}
-               .tk-title{font-size:18px;font-weight:700;letter-spacing:.2px;}
-               .tk-sub{color:#8892a6;font-size:13px}
-               </style>
-               <div class="wrap text-center">
-                               <a href="<?= esc_url(admin_url()); ?>" class="button button-secondary" id="takamoa-scanner-home">Home</a>
-                               <header class="tk-header">
-                                       <div>
-                                               <div class="tk-title"><?php echo esc_html(get_admin_page_title()); ?></div>
-                                       </div>
-                               </header>
-                               <div id="qr-reader"></div>
-                               <div id="scan-result" class="mt-3"></div>
-                               <button id="rescan-btn" class="button button-primary mt-3">Re-scan</button>
-                       </div>
-<?php
+               include plugin_dir_path(__FILE__) . 'partials/scanner-page.php';
        }
 
 	/**

--- a/admin/css/takamoa-papi-integration-admin.css
+++ b/admin/css/takamoa-papi-integration-admin.css
@@ -91,15 +91,3 @@
 	word-break: break-word;
 	font-size: 0.875rem;
 }
-#qr-reader {
-	max-width: 400px;
-	margin: 0 auto;
-}
-#scan-result {
-	max-width: 400px;
-	margin: 1rem auto;
-}
-#rescan-btn {
-        display: none;
-}
-

--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -324,21 +324,21 @@ function onScan(decodedText) {
 		nonce: takamoaAjax.nonce,
 		reference: decodedText
 	}).done(function (res) {
-		if (res.success) {
-			var html = '<div class="card"><div class="card-body"><h5>' + res.data.name + '</h5><p>Email: ' + (res.data.email || '—') + '<br>Téléphone: ' + (res.data.phone || '—') + '<br>Entreprise: ' + (res.data.description || '—') + '<br>Status: <span class="ticket-status">' + res.data.status + '</span></p>';
-			if (res.data.status === 'GENERATED') {
-				html += '<button id="validate-ticket" data-ref="' + decodedText + '" class="button button-primary mt-2">Valider le billet</button>';
-			}
-			html += '</div></div>';
-			scanResult.html(html);
-		} else {
-			scanResult.html('<div class="alert alert-danger">' + (res.data && res.data.message ? res.data.message : 'Billet introuvable') + '</div>');
-		}
-		rescanBtn.show();
-	}).fail(function () {
-		scanResult.html('<div class="alert alert-danger">Erreur de connexion</div>');
-		rescanBtn.show();
-	});
+                if (res.success) {
+                        var html = '<div class="tk-result"><div class="tk-title">' + res.data.name + '</div><div class="tk-sub">Email: ' + (res.data.email || '—') + '<br>Téléphone: ' + (res.data.phone || '—') + '<br>Entreprise: ' + (res.data.description || '—') + '<br>Status: <span class="ticket-status">' + res.data.status + '</span></div>';
+                        if (res.data.status === 'GENERATED') {
+                                html += '<button id="validate-ticket" data-ref="' + decodedText + '" class="tk-btn primary">Valider le billet</button>';
+                        }
+                        html += '</div>';
+                        scanResult.html(html);
+                } else {
+                        scanResult.html('<div class="tk-sub tk-bad">' + (res.data && res.data.message ? res.data.message : 'Billet introuvable') + '</div>');
+                }
+                rescanBtn.show();
+        }).fail(function () {
+                scanResult.html('<div class="tk-sub tk-bad">Erreur de connexion</div>');
+                rescanBtn.show();
+        });
 }
 
 startScanner();

--- a/admin/partials/scanner-page.php
+++ b/admin/partials/scanner-page.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Ticket scanner page.
+ *
+ * @since 0.0.9
+ */
+?>
+<div class="wrap container-fluid">
+    <section class="tk-wrap">
+        <style>
+            :root{
+                --bg:#0b0d12;
+                --card:#121723;
+                --muted:#8892a6;
+                --text:#e7ecf3;
+                --primary:#4f8cff;
+                --primary-press:#2f6eea;
+                --ring:rgba(79,140,255,.3);
+                --border:#283042;
+                --ok:#2ecc71;
+                --warn:#ffb020;
+                --err:#ff6b6b;
+                --radius:16px;
+                --gap:16px;
+            }
+            .tk-wrap{font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;color:var(--text);background:var(--bg);padding:24px;border-radius:var(--radius);box-shadow:0 0 0 1px #0f1320,0 10px 30px rgba(0,0,0,.35);}            
+            .tk-header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:20px;}
+            .tk-title{font-size:18px;font-weight:700;letter-spacing:.2px;}
+            .tk-sub{color:var(--muted);font-size:13px}
+            .tk-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:20px;}
+            .tk-btn{display:inline-flex;align-items:center;gap:8px;border-radius:12px;padding:10px 14px;border:1px solid var(--border);background:#0f1526;color:var(--text);cursor:pointer;transition:.15s transform,.15s background,.15s border-color;text-decoration:none;font-weight:600;}
+            .tk-btn:hover{transform:translateY(-1px);border-color:#34405a;}
+            .tk-btn:active{transform:translateY(0);}
+            .tk-btn.primary{background:var(--primary);border-color:var(--primary);color:white;}
+            .tk-btn.primary:hover{background:var(--primary-press);}
+            .tk-bad{color:var(--err);}
+            .tk-scanner{text-align:center;}
+            .tk-scanner #qr-reader{width:100%;max-width:400px;margin:0 auto;}
+            .tk-scanner #scan-result{margin-top:16px;text-align:left;}
+            .tk-scanner #rescan-btn{display:none;margin-top:16px;}
+            .tk-result .tk-btn{margin-top:16px;}
+            #wpadminbar,#adminmenumain,#adminmenuback,#adminmenuwrap{display:none;}
+            .notice{display:none;}
+            #wpcontent,#wpfooter{margin-left:0;}
+            #takamoa-scanner-home{position:fixed;top:20px;left:20px;z-index:999;}
+        </style>
+        <a href="<?= esc_url(admin_url()); ?>" class="tk-btn" id="takamoa-scanner-home">Home</a>
+        <header class="tk-header">
+            <div>
+                <div class="tk-title"><?php echo esc_html(get_admin_page_title()); ?></div>
+                <div class="tk-sub">Scannez un billet pour vérifier son statut.</div>
+            </div>
+        </header>
+        <div class="tk-card tk-scanner">
+            <div id="qr-reader"></div>
+            <div id="scan-result"></div>
+            <button id="rescan-btn" class="tk-btn primary">Re-scan</button>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- Load scanner admin page from new `scanner-page.php` partial
- Re-style scanner layout using shared `tk` components and hide admin menu
- Update scanner JS to generate markup with `tk` classes and styled errors

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l admin/partials/scanner-page.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a72ff34b64832e8724d39abc7bc243