### PR TITLE
style: center scanner page and fix mobile wpcontent

### DIFF
--- a/admin/partials/scanner-page.php
+++ b/admin/partials/scanner-page.php
@@ -23,25 +23,30 @@
                 --radius:16px;
                 --gap:16px;
             }
-            .tk-wrap{font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;color:var(--text);background:var(--bg);padding:24px;border-radius:var(--radius);box-shadow:0 0 0 1px #0f1320,0 10px 30px rgba(0,0,0,.35);}            
+            .wrap{margin:0;padding:0;}
+            .tk-wrap{font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;color:var(--text);background:var(--bg);padding:24px;border-radius:var(--radius);box-shadow:0 0 0 1px #0f1320,0 10px 30px rgba(0,0,0,.35);min-height:100vh;display:flex;flex-direction:column;align-items:center;}
             .tk-header{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:20px;}
             .tk-title{font-size:18px;font-weight:700;letter-spacing:.2px;}
             .tk-sub{color:var(--muted);font-size:13px}
             .tk-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:20px;}
+            .tk-card.tk-scanner{margin:auto;}
             .tk-btn{display:inline-flex;align-items:center;gap:8px;border-radius:12px;padding:10px 14px;border:1px solid var(--border);background:#0f1526;color:var(--text);cursor:pointer;transition:.15s transform,.15s background,.15s border-color;text-decoration:none;font-weight:600;}
             .tk-btn:hover{transform:translateY(-1px);border-color:#34405a;}
             .tk-btn:active{transform:translateY(0);}
             .tk-btn.primary{background:var(--primary);border-color:var(--primary);color:white;}
             .tk-btn.primary:hover{background:var(--primary-press);}
             .tk-bad{color:var(--err);}
-            .tk-scanner{text-align:center;}
+            .tk-scanner{text-align:center;display:flex;flex-direction:column;align-items:center;}
             .tk-scanner #qr-reader{width:100%;max-width:400px;margin:0 auto;}
             .tk-scanner #scan-result{margin-top:16px;text-align:left;}
             .tk-scanner #rescan-btn{display:none;margin-top:16px;}
             .tk-result .tk-btn{margin-top:16px;}
             #wpadminbar,#adminmenumain,#adminmenuback,#adminmenuwrap{display:none;}
             .notice{display:none;}
-            #wpcontent,#wpfooter{margin-left:0;}
+            #wpcontent,#wpfooter{margin-left:0;padding-left:0!important;}
+            @media screen and (max-width:782px){
+                .auto-fold #wpcontent{position:relative!important;margin-left:0!important;padding-left:0!important;}
+            }
             #takamoa-scanner-home{position:fixed;top:20px;left:20px;z-index:999;}
         </style>
         <a href="<?= esc_url(admin_url()); ?>" class="tk-btn" id="takamoa-scanner-home">Home</a>


### PR DESCRIPTION
## Summary
- make scanner interface full screen and center the QR reader
- override mobile `#wpcontent` padding/margin to avoid admin conflicts

## Testing
- `php -l admin/partials/scanner-page.php`
- `npm test` *(fails: could not read package.json)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a7389d6b58832e81714f275641f198