### PR TITLE
feat: export payments as CSV

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -247,7 +247,38 @@ class Takamoa_Papi_Integration_Admin
                 include plugin_dir_path(__FILE__) . 'partials/payments-page.php';
         }
 
-	/**
+        /**
+        * Export all payments as CSV with contact information.
+        *
+        * @since 0.0.8
+        */
+        public function handle_export_payments_csv()
+        {
+                if (!current_user_can('manage_options')) {
+                        wp_die('Unauthorized', 403);
+                }
+
+                check_admin_referer('takamoa_export_payments');
+
+                global $wpdb;
+                $table = $wpdb->prefix . 'takamoa_papi_payments';
+                $rows  = $wpdb->get_results("SELECT reference, client_name, payer_email, payer_phone, amount, payment_status, payment_method, created_at FROM $table ORDER BY created_at DESC", ARRAY_A);
+
+                header('Content-Type: text/csv; charset=utf-8');
+                header('Content-Disposition: attachment; filename=takamoa-payments.csv');
+
+                $output = fopen('php://output', 'w');
+                fputcsv($output, ['Reference', 'Client Name', 'Email', 'Phone', 'Amount', 'Status', 'Method', 'Date']);
+
+                foreach ($rows as $row) {
+                        fputcsv($output, $row);
+                }
+
+                fclose($output);
+                exit;
+        }
+
+        /**
 	* Display the tickets management page.
 	*
 	* @since 0.0.3

--- a/admin/partials/payments-page.php
+++ b/admin/partials/payments-page.php
@@ -50,6 +50,9 @@
                 <div class="tk-title"><?php echo esc_html(get_admin_page_title()); ?></div>
                 <div class="tk-sub">Liste des paiements effectués via Papi.mg.</div>
             </div>
+            <div class="tk-actions">
+                <a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=takamoa_export_payments' ), 'takamoa_export_payments' ) ); ?>" class="tk-btn">Exporter CSV</a>
+            </div>
         </header>
         <div class="tk-card">
             <table id="takamoa-payments-table" class="tk-table">

--- a/includes/class-takamoa-papi-integration.php
+++ b/includes/class-takamoa-papi-integration.php
@@ -79,7 +79,7 @@ class Takamoa_Papi_Integration {
 		if ( defined( 'TAKAMOA_PAPI_INTEGRATION_VERSION' ) ) {
 			$this->version = TAKAMOA_PAPI_INTEGRATION_VERSION;
 		} else {
-			$this->version = '0.0.7';
+                       $this->version = '0.0.8';
 		}
 		$this->plugin_name = 'takamoa-papi-integration';
 		$this->load_dependencies();
@@ -173,8 +173,9 @@ class Takamoa_Papi_Integration {
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 		$this->loader->add_action('admin_menu', $plugin_admin, 'add_menu');
 		$this->loader->add_action('admin_init', $plugin_admin, 'register_settings');
-        $this->loader->add_action('admin_post_takamoa_save_design', $plugin_admin, 'handle_save_design');
-        $this->loader->add_action('admin_post_takamoa_delete_design', $plugin_admin, 'handle_delete_design');
+       $this->loader->add_action('admin_post_takamoa_save_design', $plugin_admin, 'handle_save_design');
+       $this->loader->add_action('admin_post_takamoa_delete_design', $plugin_admin, 'handle_delete_design');
+       $this->loader->add_action('admin_post_takamoa_export_payments', $plugin_admin, 'handle_export_payments_csv');
         $this->loader->add_action('wp_ajax_takamoa_resend_payment_email', $this->functions, 'handle_resend_payment_email_ajax');
         $this->loader->add_action('wp_ajax_takamoa_regenerate_payment_link', $this->functions, 'handle_regenerate_payment_link_ajax');
         $this->loader->add_action('wp_ajax_takamoa_ticket_exists', $this->functions, 'handle_ticket_exists_ajax');

--- a/takamoa-papi-integration.php
+++ b/takamoa-papi-integration.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Plugin Name:       Takamoa Papi Integration
  * Plugin URI:        https://nexa.takamoa.com/nos-realisations/
  * Description:       Easily generate and track payment links via Papi.mg directly from your WordPress site. Supports MVOLA, Orange Money, Airtel Money, and BRED. Includes real-time status tracking and customizable forms.
- * Version:           0.0.7
+ * Version:           0.0.8
  * Author:            Nexa by Takamoa
  * Author URI:        https://nexa.takamoa.com/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 0.0.1 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAKAMOA_PAPI_INTEGRATION_VERSION', '0.0.7' );
+define( 'TAKAMOA_PAPI_INTEGRATION_VERSION', '0.0.8' );
 /**
  * The code that runs during plugin activation.
  * This action is documented in includes/class-takamoa-papi-integration-activator.php


### PR DESCRIPTION
## Summary
- add CSV export handler for payment records with contact info
- expose export button on payments admin page
- bump plugin version to 0.0.8

## Testing
- `php -l admin/class-takamoa-papi-integration-admin.php`
- `php -l admin/partials/payments-page.php`
- `php -l includes/class-takamoa-papi-integration.php`
- `php -l takamoa-papi-integration.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad419d7d38832e9cf3b3256d56d821