### PR TITLE
Allow updating amount when regenerating payment link

### DIFF
--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -116,35 +116,49 @@ $('#takamoa-payments-table').on('click', '.takamoa-notify', function (e) {
 });
 });
 
+
+var regenRef = '';
+var regenRow = null;
 $('#takamoa-payments-table').on('click', '.takamoa-regenerate-link', function (e) {
         e.preventDefault();
         e.stopPropagation();
+        regenRow = $(this).closest('tr');
+        regenRef = regenRow.data('reference');
+        $('#regen-amount').val(regenRow.data('amountValue'));
+        openModal('regenerateModal');
+});
+
+$('#confirm-regenerate-link').on('click', function () {
         var btn = $(this);
-        var row = btn.closest('tr');
-        var reference = btn.data('reference') || (row.length ? row.data('reference') : '');
-        if (!reference) {
+        var amount = parseFloat($('#regen-amount').val());
+        if (!regenRef || !amount) {
                 return;
         }
         btn.prop('disabled', true);
         $.post(takamoaAjax.ajaxurl, {
                 action: 'takamoa_regenerate_payment_link',
                 nonce: takamoaAjax.nonce,
-                reference: reference,
+                reference: regenRef,
+                amount: amount,
         })
                 .done(function (res) {
                         if (res.success && res.data) {
                                 alert('Lien régénéré');
-                                row.data('paymentLink', res.data.payment_link).attr('data-payment-link', res.data.payment_link);
-                                row.data('linkCreation', res.data.link_creation).attr('data-link-creation', res.data.link_creation);
-                                row.data('linkExpiration', res.data.link_expiration).attr('data-link-expiration', res.data.link_expiration);
-                                row.data('notificationToken', res.data.notification_token).attr('data-notification-token', res.data.notification_token);
-                                row.data('rawRequest', res.data.raw_request).attr('data-raw-request', res.data.raw_request);
-                                row.data('rawResponse', res.data.raw_response).attr('data-raw-response', res.data.raw_response);
-                                row.data('updatedAt', res.data.updated_at).attr('data-updated-at', res.data.updated_at);
-                                row.data('status', res.data.status).attr('data-status', res.data.status);
-                                row.data('method', res.data.payment_method).attr('data-method', res.data.payment_method);
-                                row.find('td').eq(5).text(res.data.status);
-                                row.find('td').eq(6).text(res.data.payment_method);
+                                var formatted = new Intl.NumberFormat('fr-FR').format(amount) + ' MGA';
+                                regenRow.data('amount', formatted).attr('data-amount', formatted);
+                                regenRow.data('amountValue', amount).attr('data-amount-value', amount);
+                                regenRow.data('paymentLink', res.data.payment_link).attr('data-payment-link', res.data.payment_link);
+                                regenRow.data('linkCreation', res.data.link_creation).attr('data-link-creation', res.data.link_creation);
+                                regenRow.data('linkExpiration', res.data.link_expiration).attr('data-link-expiration', res.data.link_expiration);
+                                regenRow.data('notificationToken', res.data.notification_token).attr('data-notification-token', res.data.notification_token);
+                                regenRow.data('rawRequest', res.data.raw_request).attr('data-raw-request', res.data.raw_request);
+                                regenRow.data('rawResponse', res.data.raw_response).attr('data-raw-response', res.data.raw_response);
+                                regenRow.data('updatedAt', res.data.updated_at).attr('data-updated-at', res.data.updated_at);
+                                regenRow.data('status', res.data.status).attr('data-status', res.data.status);
+                                regenRow.data('method', res.data.payment_method).attr('data-method', res.data.payment_method);
+                                regenRow.find('td').eq(4).text(formatted);
+                                regenRow.find('td').eq(5).text(res.data.status);
+                                regenRow.find('td').eq(6).text(res.data.payment_method);
                         } else {
                                 alert(
                                         res.data && res.data.message
@@ -158,6 +172,7 @@ $('#takamoa-payments-table').on('click', '.takamoa-regenerate-link', function (e
                 })
                 .always(function () {
                         btn.prop('disabled', false);
+                        closeModal('regenerateModal');
                 });
 });
 

--- a/admin/partials/payments-page.php
+++ b/admin/partials/payments-page.php
@@ -43,7 +43,9 @@
             .tk-modal,
             .tk-modal .tk-btn,
             .tk-modal .tk-close,
-            .tk-modal select{color:#fff;}
+            .tk-modal select,
+            .tk-modal input{color:#fff;}
+            .tk-modal input{width:100%;padding:8px;border:1px solid var(--border);border-radius:8px;background:#0f1526;}
         </style>
         <header class="tk-header">
             <div>
@@ -77,6 +79,7 @@
                             data-email="<?= esc_attr($row->payer_email) ?>"
                             data-phone="<?= esc_attr($row->payer_phone) ?>"
                             data-amount="<?= esc_attr(number_format($row->amount, 0, '', ' ') . ' MGA') ?>"
+                            data-amount-value="<?= esc_attr($row->amount) ?>"
                             data-status="<?= esc_attr($row->payment_status) ?>"
                             data-method="<?= esc_attr($row->payment_method ?: '—') ?>"
                             data-date="<?= esc_attr($row->created_at) ?>"
@@ -186,6 +189,22 @@
             <div class="tk-modal-footer">
                 <button type="button" class="tk-btn" data-close="ticketModal">Fermer</button>
                 <button type="button" id="generate-ticket-btn" class="tk-btn">Générer</button>
+            </div>
+        </div>
+    </div>
+
+    <div class="tk-modal" id="regenerateModal" aria-hidden="true">
+        <div class="tk-modal-content tk-card">
+            <div class="tk-modal-header">
+                <h3 class="tk-title">Regénérer le lien</h3>
+                <button type="button" class="tk-close" data-close="regenerateModal">&times;</button>
+            </div>
+            <div class="tk-modal-body">
+                <input type="number" id="regen-amount" />
+            </div>
+            <div class="tk-modal-footer">
+                <button type="button" class="tk-btn" data-close="regenerateModal">Fermer</button>
+                <button type="button" id="confirm-regenerate-link" class="tk-btn">Regénérer</button>
             </div>
         </div>
     </div>

--- a/includes/class-takamoa-papi-integration-functions.php
+++ b/includes/class-takamoa-papi-integration-functions.php
@@ -572,12 +572,17 @@ wp_mail($email, $subject, $message, $headers);
                        wp_send_json_error(['message' => 'Paiement introuvable.']);
                }
 
+               $amount = isset($_POST['amount']) ? floatval($_POST['amount']) : floatval($payment->amount);
+               if ($amount <= 0) {
+                       wp_send_json_error(['message' => 'Montant invalide.']);
+               }
+
                $api_key = get_option('takamoa_papi_api_key');
                $validDuration = intval(get_option('takamoa_papi_valid_duration', 60));
 
                $request = [
                        'clientName' => $payment->client_name,
-                       'amount' => floatval($payment->amount),
+                       'amount' => $amount,
                        'reference' => $payment->reference,
                        'description' => $payment->description ?: 'Paiement via Papi',
                        'payerEmail' => $payment->payer_email,
@@ -637,6 +642,7 @@ wp_mail($email, $subject, $message, $headers);
                                'notification_token' => $notification_token,
                                'payment_status' => 'PENDING',
                                'payment_method' => $payment_method,
+                               'amount' => $amount,
                                'raw_request' => json_encode($request),
                                'raw_response' => json_encode($body),
                                'updated_at' => $now,
@@ -654,6 +660,7 @@ wp_mail($email, $subject, $message, $headers);
                        'payment_method' => $payment_method,
                        'updated_at' => $now,
                        'status' => 'PENDING',
+                       'amount' => $amount,
                ]);
        }
 


### PR DESCRIPTION
## Summary
- allow admins to change amount when regenerating a payment link
- handle new amount in AJAX regeneration and persist to database

## Testing
- `php -l admin/partials/payments-page.php`
- `php -l includes/class-takamoa-papi-integration-functions.php`
- `node --check admin/js/takamoa-papi-integration-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68b96b718ecc832e9435b530c9e02ec5