### PR TITLE
Group payment actions into dropdown menu

### DIFF
--- a/admin/js/takamoa-papi-integration-admin.js
+++ b/admin/js/takamoa-papi-integration-admin.js
@@ -42,11 +42,22 @@ jQuery(document).ready(function ($) {
 		.find('.dataTables_filter input')
 		.addClass('form-control form-control-sm')
 		.attr('placeholder', 'Search…');
-		wrapper
-		.find('.dataTables_length label, .dataTables_filter label')
-		.addClass('d-flex align-items-center gap-2 mb-0');
-		
-		$('#takamoa-payments-table').on('click', '.takamoa-details', function (e) {
+                wrapper
+                .find('.dataTables_length label, .dataTables_filter label')
+                .addClass('d-flex align-items-center gap-2 mb-0');
+
+                $('#takamoa-payments-table').on('click', '.tk-action-toggle', function (e) {
+                        e.stopPropagation();
+                        var list = $(this).siblings('.tk-action-list');
+                        $('.tk-action-list').not(list).removeClass('show');
+                        list.toggleClass('show');
+                });
+
+                $(document).on('click', function () {
+                        $('.tk-action-list').removeClass('show');
+                });
+
+                $('#takamoa-payments-table').on('click', '.takamoa-details', function (e) {
 			e.stopPropagation();
 			var row = $(this).closest('tr');
 			$('#modal-reference').text(row.data('reference'));

--- a/admin/partials/payments-page.php
+++ b/admin/partials/payments-page.php
@@ -40,6 +40,10 @@
             .tk-btn.danger{border-color:var(--err);color:var(--err);}
             .tk-btn.danger:hover{background:rgba(255,107,107,.1);}
             .tk-actions{display:flex;gap:8px;flex-wrap:wrap;}
+            .tk-action-menu{position:relative;}
+            .tk-action-menu .tk-action-list{display:none;position:absolute;top:100%;right:0;background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:8px;flex-direction:column;gap:8px;z-index:100;}
+            .tk-action-menu .tk-action-list.show{display:flex;}
+            .tk-action-menu .tk-action-list .tk-btn{width:100%;justify-content:flex-start;}
             .tk-modal,
             .tk-modal .tk-btn,
             .tk-modal .tk-close,
@@ -110,11 +114,14 @@
                             <td><?= esc_html($row->payment_method ?: '—') ?></td>
                             <td><?= esc_html($row->created_at) ?></td>
                             <td>
-                                <div class="tk-actions">
-                                    <button type="button" class="tk-btn takamoa-notify">Notifier</button>
-                                    <button type="button" class="tk-btn takamoa-regenerate-link" data-reference="<?= esc_attr($row->reference) ?>">Regénérer le lien</button>
-                                    <button type="button" class="tk-btn takamoa-generate-ticket">Générer un billet</button>
-                                    <button type="button" class="tk-btn takamoa-details">Détails</button>
+                                <div class="tk-action-menu">
+                                    <button type="button" class="tk-btn tk-action-toggle">Actions</button>
+                                    <div class="tk-action-list">
+                                        <button type="button" class="tk-btn takamoa-notify">Notifier</button>
+                                        <button type="button" class="tk-btn takamoa-regenerate-link" data-reference="<?= esc_attr($row->reference) ?>">Regénérer le lien</button>
+                                        <button type="button" class="tk-btn takamoa-generate-ticket">Générer un billet</button>
+                                        <button type="button" class="tk-btn takamoa-details">Détails</button>
+                                    </div>
                                 </div>
                             </td>
                         </tr>


### PR DESCRIPTION
## Summary
- collapse payment row actions into an 'Actions' dropdown
- add JS/CSS to manage dropdown menu

## Testing
- `php -l admin/partials/payments-page.php`
- `node --check admin/js/takamoa-papi-integration-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68b971982018832eb1fb4960c91e229b