### PR TITLE
Remove payments admin query limit

### DIFF
--- a/admin/class-takamoa-papi-integration-admin.php
+++ b/admin/class-takamoa-papi-integration-admin.php
@@ -239,7 +239,7 @@ class Takamoa_Papi_Integration_Admin
         {
                 global $wpdb;
                 $table         = $wpdb->prefix . 'takamoa_papi_payments';
-                $results       = $wpdb->get_results('SELECT * FROM ' . $table . ' ORDER BY created_at DESC LIMIT 100');
+                $results       = $wpdb->get_results('SELECT * FROM ' . $table . ' ORDER BY created_at DESC');
                 $design_table  = $wpdb->prefix . 'takamoa_papi_designs';
                 $designs       = $wpdb->get_results('SELECT id, title FROM ' . $design_table . ' ORDER BY created_at DESC');
                 $default_design = intval(get_option('takamoa_papi_default_design'));


### PR DESCRIPTION
## Summary
- load the full payments history when rendering the admin payments table so the DataTables pagination can access every entry

## Testing
- php -l admin/class-takamoa-papi-integration-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68ce4df745d8832eb5276a4551460d51